### PR TITLE
Guides: restart walkthrough step numbering at 1 and end sections with takeaways for last steps.

### DIFF
--- a/guides/02_03_first_compliant_resource.md
+++ b/guides/02_03_first_compliant_resource.md
@@ -43,7 +43,7 @@ One primary bucket holds your data. A separate log bucket receives S3 server acc
 
 ## Step-by-step walkthrough
 
-### 5.1 Create the project structure
+### Step 1 Create the project structure
 
 ```bash
 mkdir -p terraform/primitives/compliant-s3 && cd terraform/primitives/compliant-s3
@@ -52,7 +52,7 @@ touch main.tf variables.tf outputs.tf README.md
 
 This is the directory shape every lab will reuse. By Ch 7 your capstone repo will have a dozen of these.
 
-### 5.2 Write the base bucket + tags
+### Step 2 Write the base bucket + tags
 
 Open `main.tf` and start with the provider configuration. The `default_tags` block makes the four required compliance tags non-optional, every taggable resource you create from this provider gets them automatically.
 
@@ -125,7 +125,7 @@ variable "bucket_suffix" {
 }
 ```
 
-### 5.3 Add encryption, versioning, public access block
+### Step 3 Add encryption, versioning, public access block
 
 Three resources, three controls.
 
@@ -173,7 +173,7 @@ resource "aws_s3_bucket_public_access_block" "primary" {
 
 All four flags must be `true`. Three is not enough. AWS treats them as independent doors.
 
-### 5.4 Add the log bucket and wire up access logging
+### Step 4 Add the log bucket and wire up access logging
 
 The log bucket needs its own encryption and public-access-block, plus an ACL allowing the S3 log delivery group to write into it. Define it before the `aws_s3_bucket_logging` that points at it.
 
@@ -239,7 +239,7 @@ output "encryption_algorithm" {
 
 > **Why the `one(...)` expression:** Terraform represents the `rule` block of `aws_s3_bucket_server_side_encryption_configuration` as a *set*, not a list. Sets are not index-addressable. The `for` expression flattens the single rule into a list, then `one()` extracts the lone element, failing loudly if there's ever more than one. This is the kind of thing that catches you off-guard the first time and never again.
 
-### 5.5 terraform init / plan / apply
+### Step 5 terraform init / plan / apply
 
 If you're using AWS SSO, export your credentials so Terraform's AWS provider can use them:
 
@@ -271,7 +271,7 @@ log_bucket_arn = "arn:aws:s3:::cgep-lab-dev-logs-XXXXXXXX"
 
 Eleven resources, four outputs. Your bucket suffix will differ.
 
-### 5.6 Capture evidence with `terraform show -json`
+### Step 6 Capture evidence with `terraform show -json`
 
 ```bash
 mkdir -p evidence

--- a/guides/02_04_terraform_modules_for_compliance.md
+++ b/guides/02_04_terraform_modules_for_compliance.md
@@ -50,11 +50,11 @@ The module produces one keyring, one CMEK, one IAM binding, one bucket. Two cons
 
 ## Step-by-step walkthrough
 
-### 5.1 Why a module
+### Concept: Why a module
 
 A module is a directory of Terraform with a clear interface: inputs, outputs, and a body. The body decides what's hardcoded. The interface decides what consumers can change. If you've done Lab 2.3, you wrote one bucket on AWS. This time you write one module on GCP and call it twice.
 
-### 5.2 Design the interface
+### Concept: Design the interface
 
 Three rules:
 
@@ -64,7 +64,7 @@ Three rules:
 
 Consumers write a few lines. The module enforces the rest.
 
-### 5.3 Build `modules/compliant-gcs-bucket/main.tf`
+### Step 1 Build `modules/compliant-gcs-bucket/main.tf`
 
 ```hcl
 # main.tf
@@ -145,7 +145,7 @@ resource "google_storage_bucket" "bucket" {
 
 Required labels live in `locals`, then merge on top of `var.labels`. A consumer can add labels but cannot suppress the four compliance ones. That asymmetry is the point.
 
-### 5.4 Build `variables.tf` with validation
+### Step 2 Build `variables.tf` with validation
 
 ```hcl
 # variables.tf
@@ -217,7 +217,7 @@ variable "labels" {
 
 > **Why two location vars:** GCS buckets accept multi-region names like `US` and `EU`. KMS keyrings do not. The first time I tried `var.location = "US"` for both, KMS rejected with `KMS_RESOURCE_NOT_FOUND_IN_LOCATION`. Splitting the variable keeps the lesson honest. Both default to `us-central1`.
 
-### 5.5 Build `outputs.tf` returning compliance evidence
+### Step 3 Build `outputs.tf` returning compliance evidence
 
 ```hcl
 # outputs.tf
@@ -254,7 +254,7 @@ output "compliance_attestation" {
 
 `compliance_attestation` is the bridge to Lab 3 (Rego asserts on it) and Lab 6 (OSCAL evidence URI points at the JSON it ends up in).
 
-### 5.6 Write consumer #1: dev environment, 30-day retention
+### Step 4 Write consumer #1: dev environment, 30-day retention
 
 ```hcl
 # consumers/dev/main.tf
@@ -286,7 +286,7 @@ output "bucket_url"  { value = module.data_bucket.bucket_url }
 
 Six lines of business config. Twenty-plus controls.
 
-### 5.7 Write consumer #2: prod environment, 365-day retention
+### Step 5 Write consumer #2: prod environment, 365-day retention
 
 Same module, swap two values:
 
@@ -305,7 +305,7 @@ module "data_bucket" {
 
 (Same provider block, same outputs.)
 
-### 5.8 Apply and observe
+### Step 6 Apply and observe
 
 Run the cycle on dev. For lab purposes, prod-plan but don't apply (a 365-day retention lock takes a year to expire):
 
@@ -333,7 +333,7 @@ bucket_url = "gs://cgep-lab-dev-dev-data-001"
 
 That output is the SC-12 / SC-13 / SC-28 / AC-3 / CM-6 / AU-11 attestation in machine-readable form.
 
-### 5.9 The negative test
+### Step 7 The negative test
 
 Copy `consumers/dev` to `consumers/negative-test`, change `environment` to `prod`, leave `retention_days` at 30, and run plan:
 

--- a/guides/02_05_iac_as_compliance_evidence.md
+++ b/guides/02_05_iac_as_compliance_evidence.md
@@ -40,11 +40,11 @@ The capture script reads from your Lab 2.3 workspace, hashes everything, tars it
 
 ## Step-by-step walkthrough
 
-### 5.1 Why code is evidence
+### Concept: Why code is evidence
 
 A screenshot of an AWS console says "I once saw this." A Terraform plan committed to git, reviewed in a pull request, applied in CI, and stored in a vault that refuses deletion says "this is what was deployed, who reviewed it, when, and the artifact is unchanged since." Three properties auditors want: integrity, attribution, reproducibility. Code-as-evidence delivers all three. Screenshots deliver none.
 
-### 5.2 Build the evidence vault
+### Step 1 Build the evidence vault
 
 Object Lock has one critical constraint: it must be enabled at bucket creation. You cannot retrofit it. Start fresh.
 
@@ -160,7 +160,7 @@ variable "retention_days" {
 
 > **GOVERNANCE vs COMPLIANCE.** GOVERNANCE retention can be bypassed by a privileged caller using `--bypass-governance-retention`. COMPLIANCE cannot be bypassed by anyone, including root, until the retention window expires. Use GOVERNANCE for lab work so you can clean up. Use COMPLIANCE for real evidence. The script and the rest of the pattern are identical either way.
 
-### 5.3 Write `capture-evidence.sh`
+### Step 2 Write `capture-evidence.sh`
 
 A single bash script. Reads the workspace, builds a manifest, uploads, prints a JSON receipt to stdout that downstream pipelines can pipe.
 
@@ -241,7 +241,7 @@ printf '{"run_id":"%s","vault":"%s","key":"%s","version_id":"%s","captured_at_ut
 
 `set -euo pipefail` plus the `trap` handles partial-failure cleanup. The single-line JSON receipt at the end is what your CI pipeline captures and stores.
 
-### 5.4 Run it against Lab 2.3's workspace
+### Step 3 Run it against Lab 2.3's workspace
 
 ```bash
 chmod +x scripts/capture-evidence.sh
@@ -266,7 +266,7 @@ Receipt:
 
 The VersionId is the durable handle. Save it. Anything that points at this evidence in the future (your OSCAL component's evidence URI, for example) uses `s3://VAULT/KEY?versionId=...`.
 
-### 5.5 Verify in S3
+### Step 4 Verify in S3
 
 ```bash
 aws s3api get-object-retention \
@@ -286,7 +286,7 @@ Expected:
 
 The retention date is set by the bucket's default rule, applied at upload. You did not have to set it explicitly.
 
-### 5.6 The destructive test
+### Step 5 The destructive test
 
 This is the lesson. Try to delete the object you just uploaded.
 
@@ -307,7 +307,7 @@ Access Denied because object protected by object lock.
 
 That message is the proof of immutability. A pipeline that uploads here, and an auditor who reads from here, both rely on this rejection. The lesson is not that S3 has a feature called Object Lock; the lesson is that your evidence is now resistant to silent tampering by an admin who would rather the evidence not exist.
 
-### 5.7 Optional: sign the bundle with Cosign
+### Step 6 Optional: sign the bundle with Cosign
 
 Cosign keyless signing uses Sigstore's public Fulcio CA. From a laptop you authenticate via OIDC. From CI (Lab 4.4) the GitHub OIDC token flows automatically.
 

--- a/guides/03_03_writing_compliance_policies_rego.md
+++ b/guides/03_03_writing_compliance_policies_rego.md
@@ -31,13 +31,13 @@ Every deny message includes the resource address AND the NIST control ID. The de
 
 ## Step-by-step walkthrough
 
-### 5.1 Project structure
+### Step 1 Project structure
 
 ```bash
 mkdir -p policies/tests terraform fixtures
 ```
 
-### 5.2 The test bed
+### Step 2 The test bed
 
 A small Terraform fixture with both compliant and non-compliant resources gives the policy suite something concrete to flag.
 
@@ -115,7 +115,7 @@ terraform show -json tfplan > plan.json
 
 You don't have to apply. The policies operate on `plan.json`.
 
-### 5.3 SC-28: Encryption at Rest
+### Step 3 SC-28: Encryption at Rest
 
 ```rego
 # policies/sc28_encryption.rego
@@ -164,7 +164,7 @@ empty_kms_key(enc) if enc.default_kms_key_name == null
 
 > **Why `has_cmek` checks the block, not the value.** At plan time, the KMS key resource ID is "(known after apply)" because Terraform hasn't created the key yet. The plan JSON omits unknown values entirely. We accept any non-empty `encryption` block as "configured", and only fail when the block is missing or holds an empty/null key name. This is the correct policy semantics: the developer wired CMEK, the value resolves at apply.
 
-### 5.4 SC-28 tests
+### Step 4 SC-28 tests
 
 ```rego
 # policies/tests/sc28_encryption_test.rego
@@ -203,7 +203,7 @@ opa test -v policies/
 
 Both tests pass. Move on.
 
-### 5.5 AC-3: No public access
+### Step 5 AC-3: No public access
 
 Two rule sets in one file: buckets and firewalls.
 
@@ -272,7 +272,7 @@ deny contains msg if {
 }
 ```
 
-### 5.6 AC-3 tests
+### Step 6 AC-3 tests
 
 ```rego
 # policies/tests/ac3_no_public_test.rego
@@ -307,7 +307,7 @@ test_open_management_port_fails if {
 }
 ```
 
-### 5.7 CM-6: Required labels
+### Step 7 CM-6: Required labels
 
 This one uses set subtraction. Required labels are a set; the resource's labels are a set; the difference is what's missing.
 
@@ -384,7 +384,7 @@ test_partial_fails    if { some msg in cm6.deny with input as missing;   contain
 test_no_labels_fail   if { some msg in cm6.deny with input as no_labels; contains(msg, "CM-6") }
 ```
 
-### 5.8 Run the full library against the real plan
+### Step 8 Run the full library against the real plan
 
 ```bash
 opa test -v policies/
@@ -414,7 +414,7 @@ Expected:
 
 Each non-compliant resource is flagged exactly once by the right control. The good bucket is quiet.
 
-### 5.9 Fix the broken Terraform, re-eval
+### Step 9 Fix the broken Terraform, re-eval
 
 Add the missing pieces to your fixture, regenerate `plan.json`, run the same evals. Every deny set is empty.
 

--- a/guides/03_04_integrating_pac_with_terraform.md
+++ b/guides/03_04_integrating_pac_with_terraform.md
@@ -32,7 +32,7 @@ You wrote three Rego policies in Lab 3.3 against GCP fixtures. This lab does two
 
 ## Step-by-step walkthrough
 
-### 5.1 Carry the Lab 3.3 library forward, run its tests
+### Step 1 Carry the Lab 3.3 library forward, run its tests
 
 ```bash
 cp -r ../lab-3-3/policies ./policies
@@ -41,7 +41,7 @@ opa test -v policies/    # 8/8 PASS
 
 Sanity check the library still works in this workspace before extending it.
 
-### 5.2 Generate plan.json from Lab 2.3
+### Step 2 Generate plan.json from Lab 2.3
 
 ```bash
 cd ../lab-2-3
@@ -53,7 +53,7 @@ terraform show -json tfplan > plan.json
 
 Copy `plan.json` into the Conftest workspace, or point Conftest at it directly.
 
-### 5.3 The cross-cloud lesson
+### Step 3 The cross-cloud lesson
 
 Run the GCP policies against the AWS plan:
 
@@ -67,7 +67,7 @@ The first two pass with zero coverage. They check `google_storage_bucket` and `g
 
 The lesson: a control ID is portable, but a Rego rule that hardcodes `resource.type == "google_storage_bucket"` is not. Either you generalize the rule or you add per-cloud variants. Adding variants keeps each rule readable; generalizing makes one rule that handles every type. We add variants here.
 
-### 5.4 Add the AWS variant of SC-28
+### Step 4 Add the AWS variant of SC-28
 
 ```rego
 # policies/sc28_encryption_aws.rego
@@ -112,7 +112,7 @@ references_bucket(ref, bucket_addr) if ref == sprintf("%s.bucket", [bucket_addr]
 
 > **Why match by reference, not by value.** At plan time, the bucket name is "(known after apply)" because the random_id suffix isn't generated yet. Both `aws_s3_bucket.values.bucket` and the encryption resource's `values.bucket` are `null` in the JSON. Use `configuration.root_module.resources[].expressions.bucket.references` instead. Each reference is a string like `"aws_s3_bucket.primary.id"` that Terraform resolves at apply.
 
-### 5.5 Add the AWS variant of AC-3
+### Step 5 Add the AWS variant of AC-3
 
 The AWS variant is more discriminating than the GCP one: it requires a public-access-block resource AND that all four flags are set true.
 
@@ -171,7 +171,7 @@ pab_planned_values(addr) := values if {
 }
 ```
 
-### 5.6 Add the AWS variant of CM-6
+### Step 6 Add the AWS variant of CM-6
 
 The GCP rule used `labels`. AWS uses `tags`. With provider `default_tags` enabled, the merged tag set lives in `tags_all`.
 
@@ -232,7 +232,7 @@ tag_keys(resource) := set() if {
 sort_array(s) := sorted if { sorted := sort([x | some x in s]) }
 ```
 
-### 5.7 Run the gate against the compliant plan
+### Step 7 Run the gate against the compliant plan
 
 ```bash
 for ns in compliance.sc28_aws compliance.ac3_aws compliance.cm6_aws ; do
@@ -254,7 +254,7 @@ Expected:
 
 Lab 2.3's plan now has full AWS coverage from your policy library.
 
-### 5.8 Break it and watch the gate fire
+### Step 8 Break it and watch the gate fire
 
 Copy the Lab 2.3 workspace, remove the primary bucket's encryption configuration block, regenerate the plan, run Conftest:
 
@@ -276,7 +276,7 @@ FAIL - broken/plan.json - compliance.sc28_aws - [SC-28] aws_s3_bucket.primary: a
 
 The exit code is non-zero. The deny message names the resource, the control, and the fix. A developer reading the failed PR knows exactly what to do.
 
-### 5.9 The wrapper script
+### Step 9 The wrapper script
 
 The CI workflow in Lab 4.3 calls a single script. Build it now.
 

--- a/guides/04_03_grc_evidence_pipeline.md
+++ b/guides/04_03_grc_evidence_pipeline.md
@@ -37,7 +37,7 @@ Lab 4.4 adds Cosign signing and uploads the bundle to the Lab 2.5 vault.
 
 ## Step-by-step walkthrough
 
-### 5.1 Set up GitHub OIDC trust with AWS
+### Step 1 Set up GitHub OIDC trust with AWS
 
 A small Terraform module creates the OIDC provider and a read-only role scoped to your repo.
 
@@ -104,7 +104,7 @@ terraform apply -var=github_org=YourOrg -var=github_repo=YourRepo
 
 The `StringLike` on `sub` keeps this role bound to one specific repository. Don't loosen it. A role trusted by `repo:*:*` is trusted by every public repo on GitHub.
 
-### 5.2 Add the role ARN as a repo variable
+### Step 2 Add the role ARN as a repo variable
 
 ```bash
 gh variable set AWS_ROLE_ARN \
@@ -112,7 +112,7 @@ gh variable set AWS_ROLE_ARN \
   --repo YourOrg/YourRepo
 ```
 
-### 5.3 Write the workflow
+### Step 3 Write the workflow
 
 ```yaml
 # .github/workflows/grc-gate.yml
@@ -230,7 +230,7 @@ A few specific choices worth understanding:
 - **`|| true`** after the conftest and tfsec calls. The tools exit non-zero on findings; we want the JSON output regardless. The pass/fail decision is made by the python3 inline checks that follow.
 - **Pinned versions** on every action. Floating tags drift. Pin them.
 
-### 5.4 Open a PR and watch it run
+### Step 4 Open a PR and watch it run
 
 ```bash
 git checkout -b add-grc-gate
@@ -256,7 +256,7 @@ tfsec high+critical: 12
 
 Both gates fired. The starter has eight named gaps, so this is the expected outcome. The evidence artifact `grc-evidence-<run-id>` is attached to the run with `plan.json`, `conftest-results.json`, `tfsec.sarif`, and the human-readable `plan.txt`.
 
-### 5.5 The two-PR demonstration
+### Step 5 The two-PR demonstration
 
 The capstone wants both a green and a red PR in your repo's history. To produce them:
 
@@ -265,7 +265,7 @@ The capstone wants both a green and a red PR in your repo's history. To produce 
 
 Both runs leave evidence artifacts in the workflow history. Both URLs go in your capstone write-up.
 
-### 5.6 The YAML file is itself evidence
+### Takeaway: The YAML file is itself evidence
 
 Every line in `.github/workflows/grc-gate.yml` is a control statement.
 

--- a/guides/04_04_evidence_chain_of_custody.md
+++ b/guides/04_04_evidence_chain_of_custody.md
@@ -51,13 +51,13 @@ You have a pipeline. You have an immutable vault. This lab connects them with cr
 
 ## Step-by-step walkthrough
 
-### 5.1 Why signing matters
+### Concept: Why signing matters
 
 Lab 2.5 made the bundle immutable. Object Lock prevents deletion, but it doesn't prove who created the bundle or when. A determined insider with admin in the AWS account can stand up a *different* bucket, drop a tampered bundle, and point a sloppy auditor at it. Cosign closes that loop. The signature ties the bundle to a specific GitHub Actions run on a specific repository at a specific moment. The certificate Sigstore issues includes the OIDC subject (`repo:GRCEngClub/cgep-app-starter:ref:refs/pull/...`). The Rekor transparency log timestamps it. None of that is bypassable by anyone with admin in your AWS account, because none of it lives in your AWS account.
 
 Three ways the chain breaks: mutable storage (Lab 2.5 fixed that), no signing (this lab), short retention (Lab 2.5 default-retention fixed that). Close all three or you have a story, not a chain.
 
-### 5.2 Add Cosign to the workflow
+### Step 1 Add Cosign to the workflow
 
 Two new steps in `.github/workflows/grc-gate.yml`. After the existing scan and plan steps:
 
@@ -109,7 +109,7 @@ The `--bundle evidence.sig.bundle` flag packs the signature, the certificate Sig
 
 > **Important**: in Lab 4.3 the policy gate exited the job on failure. Here we want to sign and store the evidence even when the gate fails, so the evidence trail is preserved. Move the pass/fail decision to the *last* step in the job. Lab 4.4's reference workflow does this.
 
-### 5.3 Grant the role write to the vault
+### Step 2 Grant the role write to the vault
 
 The Lab 4.3 OIDC role had `ReadOnlyAccess`. Grant a tight write inline policy on the vault:
 
@@ -135,7 +135,7 @@ gh variable set EVIDENCE_VAULT --body "$VAULT" --repo OWNER/REPO
 
 Two scopes only: the vault and its objects. Nothing else.
 
-### 5.4 The verify script
+### Step 3 The verify script
 
 ```bash
 #!/usr/bin/env bash
@@ -185,7 +185,7 @@ echo "CHAIN INTACT for run ${RUN_ID}"
 
 Three checks, three exits if any fail. The output you want to see at the end is one line: `CHAIN INTACT`.
 
-### 5.5 Trigger a fresh PR
+### Step 4 Trigger a fresh PR
 
 Push the workflow update. The next PR run produces signed bundles. From your laptop:
 
@@ -207,7 +207,7 @@ Verified OK
 CHAIN INTACT for run 24963918994
 ```
 
-### 5.6 The tamper test
+### Step 5 The tamper test
 
 Download the bundle. Modify a single byte. Re-run `verify-evidence.sh`. The integrity step fails immediately. The signature, computed over the original bytes, now disagrees with the modified file's SHA. That failure is the lesson: chain of custody is mathematical, not aspirational.
 

--- a/guides/05_02_aws_security_services.md
+++ b/guides/05_02_aws_security_services.md
@@ -41,11 +41,11 @@ If you destroy within an hour of applying, expect under $1 charged. Leaving Secu
 
 ## Step-by-step walkthrough
 
-### 5.1 Why baseline services beat point tools
+### Concept: Why baseline services beat point tools
 
 Every cloud security vendor will sell you a slick console. CloudTrail, Config, and Security Hub are inside the platform you're already paying for, mapped to the same NIST controls auditors ask about, and producing JSON you can pipe into your existing pipeline. They aren't pretty. They're durable. Pick the durable one.
 
-### 5.2 CloudTrail
+### Step 1 CloudTrail
 
 Multi-region, with log-file validation on (AU-10). The bucket policy must scope the `aws:SourceArn` condition to the trail you're about to create.
 
@@ -125,7 +125,7 @@ resource "aws_cloudtrail" "mgmt" {
 
 `enable_log_file_validation = true` makes CloudTrail emit a digest file every hour signed by an AWS-managed key. Your auditor can use it to detect tampering. That's AU-10 (integrity of audit information) for free.
 
-### 5.3 Security Hub
+### Step 2 Security Hub
 
 Two standards subscribed: NIST 800-53 Rev 5 and AWS Foundational Security Best Practices. Both are free to subscribe to; you pay per security check.
 
@@ -149,7 +149,7 @@ If Security Hub is already enabled in the account from a previous experiment or 
 terraform import aws_securityhub_account.this <ACCOUNT_ID>
 ```
 
-### 5.4 AWS Config (may be SCP-blocked)
+### Step 3 AWS Config (may be SCP-blocked)
 
 The reference Terraform includes a Config recorder + delivery channel + IAM role + bucket. Org-managed accounts often have an SCP like:
 
@@ -170,7 +170,7 @@ then Config is centrally managed in your org and the lab's Terraform should be c
 
 That finding is its own evidence: your account is reporting on its own gap.
 
-### 5.5 Apply and wait
+### Step 4 Apply and wait
 
 ```bash
 eval "$(aws configure export-credentials --profile <your-sandbox> --format env)"
@@ -180,7 +180,7 @@ terraform apply -auto-approve
 
 Wait 10 to 20 minutes. Security Hub findings populate slowly on first deploy.
 
-### 5.6 Verify
+### Step 5 Verify
 
 ```bash
 aws cloudtrail get-trail-status --name cgep-lab-mgmt --region us-east-1 \
@@ -208,7 +208,7 @@ Reference run output (after Security Hub had been enabled for a few minutes):
 
 In a freshly-deployed account, expect anywhere from 1 to ~50 findings within an hour. The first batch is mostly account-level controls (CloudTrail config, root account, password policy).
 
-### 5.7 Capture findings as evidence
+### Step 6 Capture findings as evidence
 
 ```bash
 mkdir -p evidence/lab-5-2

--- a/guides/05_04_gcp_security_services.md
+++ b/guides/05_04_gcp_security_services.md
@@ -46,11 +46,11 @@ If your project sits inside an Organization and you want to apply Org Policy at 
 
 ## Step-by-step walkthrough
 
-### 5.1 Why identity-first
+### Concept: Why identity-first
 
 GCP's bet is that the smallest unit of security is the principal, not the resource. Org Policy enforces at the API call: a bucket creation attempt that violates `uniformBucketLevelAccess` is REJECTED, not flagged. WIF replaces "create a service account, download a JSON key, paste into GitHub Secrets, hope nobody leaks it" with "the GitHub Actions runtime presents an OIDC token, GCP swaps it for a short-lived access token, the token expires automatically." The two together make whole categories of attack uneconomical.
 
-### 5.2 Org Policy at project scope
+### Step 1 Org Policy at project scope
 
 ```hcl
 resource "google_org_policy_policy" "uniform_bucket_access" {
@@ -83,7 +83,7 @@ resource "google_org_policy_policy" "require_oslogin" {
 
 `enforce = "TRUE"` is rejection at the API. To audit-only-without-rejection, omit the rules block; the policy is then in "inherited" state and only visible in the policy listing.
 
-### 5.3 Test the enforcement
+### Step 2 Test the enforcement
 
 After apply, intentionally try to violate one:
 
@@ -102,7 +102,7 @@ constraint iam.disableServiceAccountKeyCreation
 
 This is the lesson. The control didn't fire after the fact in a Security Hub finding three hours later. The action didn't happen. That's defense-in-depth's strongest layer.
 
-### 5.4 Workload Identity Federation
+### Step 3 Workload Identity Federation
 
 Pool, provider, service account, IAM binding. The `attribute_condition` is critical. Without it, ANY GitHub repo on the public internet can use this provider to impersonate your service account.
 
@@ -166,7 +166,7 @@ steps:
 
 The token is minted at job start, expires after one hour, never lands on disk. Same security posture as the AWS OIDC pattern in Lab 4.3, different cloud.
 
-### 5.5 Enable Data Access audit logs
+### Step 4 Enable Data Access audit logs
 
 Off by default. This is the most-cited GCP audit finding because nobody turns them on.
 
@@ -205,7 +205,7 @@ gcloud logging read 'protoPayload.serviceName="storage.googleapis.com" AND \
   protoPayload.methodName=~"storage.objects.list"' --limit 5 --format=json
 ```
 
-### 5.6 Security Command Center
+### Step 5 Security Command Center
 
 If your project sits in an Organization with Security Command Center enabled, findings flow in automatically. SCC Standard is free at the org level; Premium is enterprise-priced and not used here. The lab does not provision SCC because it requires org admin; if you have it, dump findings as evidence:
 

--- a/guides/06_01_introduction_to_oscal.md
+++ b/guides/06_01_introduction_to_oscal.md
@@ -42,7 +42,7 @@ OSCAL is NIST's machine-readable format for security controls, profiles, compone
 
 ## Step-by-step walkthrough
 
-### 5.1 The five OSCAL models
+### Concept: The five OSCAL models
 
 | Model | What it describes | Built in this lab |
 |---|---|---|
@@ -52,7 +52,7 @@ OSCAL is NIST's machine-readable format for security controls, profiles, compone
 | System Security Plan (SSP) | A whole system's controls + components. | Stretch goal for capstone. |
 | Assessment Plan / Results | What the auditor planned, what the auditor found. | Out of scope. |
 
-### 5.2 Initialize a trestle workspace
+### Step 1 Initialize a trestle workspace
 
 ```bash
 pip install compliance-trestle
@@ -62,7 +62,7 @@ trestle init
 
 You'll get an OSCAL-shaped directory: `catalogs/`, `profiles/`, `component-definitions/`, etc.
 
-### 5.3 Create the component definition skeleton
+### Step 2 Create the component definition skeleton
 
 ```bash
 trestle create -t component-definition -o compliant-s3-v1 -x json
@@ -70,7 +70,7 @@ trestle create -t component-definition -o compliant-s3-v1 -x json
 
 Trestle generates a minimal valid skeleton. Open `component-definitions/compliant-s3-v1/component-definition.json` and replace it with the real document.
 
-### 5.4 The component definition
+### Step 3 The component definition
 
 ```json
 {
@@ -134,7 +134,7 @@ Add similar `implemented-requirements` for `ac-3`, `au-3`, and `cm-6`. The full 
 
 > **Generate UUIDs the right way.** OSCAL requires v4 UUIDs (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx` where `y` is 8/9/a/b). Don't hand-write them. Run `python3 -c "import uuid; print(uuid.uuid4())"` per UUID. `trestle validate` rejects the wrong format with a regex error; this catches you the first time you try.
 
-### 5.5 Validate
+### Step 4 Validate
 
 ```bash
 trestle validate -f component-definitions/compliant-s3-v1/component-definition.json
@@ -147,7 +147,7 @@ VALID: Model .../component-definition.json passed the Validator
 to confirm the model passes all registered validation tests.
 ```
 
-### 5.6 The Profile
+### Step 5 The Profile
 
 A profile selects which controls from the catalog this component covers.
 
@@ -186,7 +186,7 @@ Validate:
 trestle validate -f profiles/cge-p-minimum/profile.json
 ```
 
-### 5.7 Resolve the profile against the catalog
+### Step 6 Resolve the profile against the catalog
 
 ```bash
 trestle profile-resolve -n cge-p-minimum -o cge-p-minimum-resolved
@@ -194,7 +194,7 @@ trestle profile-resolve -n cge-p-minimum -o cge-p-minimum-resolved
 
 Trestle fetches the NIST catalog, applies your selection, and writes a resolved profile, the flat list of controls your component is responsible for. This is what an SSP would import.
 
-### 5.8 Demonstrate the traversal
+### Step 7 Demonstrate the traversal
 
 Pick `sc-28` in your component definition. Follow the `links[rel=evidence].href` to the vault. Run Lab 4.4's `verify-evidence.sh`:
 


### PR DESCRIPTION
Every walkthrough started at 5.1 — a template carryover with no outer "Section 5". Renumber to "Step 1, Step 2, ..." so numbers reflect the actual count of reader actions.

Knowledge-only headings are pulled out of the step sequence:
- "Concept:" for primer-style explainers
- "Takeaway:" for end-of-walkthrough reflections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guide structure across compliance and evidence-building documentation by standardizing walkthrough headings to use consistent "Step N" numbering and "Concept" labels, replacing the previous numeric scheme for improved readability, clarity, and easier navigation through instructional content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->