### PR TITLE
guides 02_04: fix step 7 so the negative test reaches the validation error

### DIFF
--- a/guides/02_04_terraform_modules_for_compliance.md
+++ b/guides/02_04_terraform_modules_for_compliance.md
@@ -335,10 +335,10 @@ That output is the SC-12 / SC-13 / SC-28 / AC-3 / CM-6 / AU-11 attestation in ma
 
 ### Step 7 The negative test
 
-Copy `consumers/dev` to `consumers/negative-test`, change `environment` to `prod`, leave `retention_days` at 30, and run plan:
+Copy `consumers/dev` to `consumers/negative-test`. Change `environment` to `prod`, change `bucket_name_suffix` to `"should-never-exist"`, leave `retention_days` at 30, and run plan:
 
 ```hcl
-module "broken_bucket" {
+module "data_bucket" {
   source = "../../modules/compliant-gcs-bucket"
 
   gcp_project        = "your-gcp-project"


### PR DESCRIPTION
## Summary

Following lab 2.4 step 7 verbatim does not produce the validation error the lab is supposed to demonstrate. The reader instead hits a `Reference to undeclared module` error from Terraform.

## What's broken

Step 7 says:

> Copy `consumers/dev` to `consumers/negative-test`, change `environment` to `prod`, leave `retention_days` at 30, and run plan:

The shown snippet renames the module:

```hcl
module "broken_bucket" {
  ...
}
```

But the copied `consumers/dev/main.tf` has these outputs at the bottom:

```hcl
output "attestation" { value = module.data_bucket.compliance_attestation }
output "bucket_url"  { value = module.data_bucket.bucket_url }
```

After the rename, those outputs reference an undeclared module. `terraform plan` errors out before variable validation runs:

```
Error: Reference to undeclared module

  on main.tf line 23, in output "attestation":
  23: output "attestation" { value = module.data_bucket.compliance_attestation }

No module call named "data_bucket" is declared in the root module.
```

The intended `retention_days must be >= 365 when environment == "prod"` error is unreachable.

## Fix

Two small changes in step 7:

1. Keep the module name as `data_bucket` in the snippet so the dev consumer's outputs still resolve after the copy.
2. Update the prose to also list `bucket_name_suffix` as a value to change. It currently appears only in the snippet, easy to miss when the prose says "change environment to prod, leave retention_days at 30".

Smallest possible diff (2 lines).

## Verification

With this fix applied locally, running step 7 verbatim:

```
$ terraform plan
...
retention_days must be >= 365 when environment == "prod".

This was checked by the validation rule at .../variables.tf:45,3-13.
```

The validation fires at plan time, before any resource is created. That's the lesson step 7 is teaching.

## Test plan

- [x] Followed lab 2.4 verbatim through step 6 on a real GCP project, dev consumer applied, attestation output matches the guide
- [x] Ran step 7 verbatim against current `main`, reproduced the `Reference to undeclared module` error
- [x] Applied the fix in this PR locally, reran step 7, got the intended validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a negative test example in the Terraform modules compliance guide to clarify test scenarios and improve readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->