### PR TITLE
guides 02_05: fix step 1 variables.tf comma-in-block HCL syntax error

### DIFF
--- a/guides/02_05_iac_as_compliance_evidence.md
+++ b/guides/02_05_iac_as_compliance_evidence.md
@@ -139,7 +139,10 @@ resource "aws_s3_bucket_policy" "vault" {
 
 ```hcl
 # terraform/variables.tf
-variable "project_name" { type = string, default = "cgep-lab" }
+variable "project_name" {
+  type    = string
+  default = "cgep-lab"
+}
 
 variable "lock_mode" {
   type        = string


### PR DESCRIPTION
## Summary

Lab 2.5 step 1 includes a `variables.tf` snippet that does not parse as valid Terraform HCL. Pasting it verbatim and running `terraform init` fails before any provider plugins are downloaded, blocking the entire lab.

## What's broken

The first variable in step 1's `# terraform/variables.tf` block:

```hcl
variable "project_name" { type = string, default = "cgep-lab" }
```

Inside an HCL block, arguments are separated by newlines or whitespace, not commas. Single-line block syntax is also limited to one argument total. `terraform init` rejects it:

```
Error: Invalid single-argument block definition

  on variables.tf line 1, in variable "project_name":
   1: variable "project_name" { type = string, default = "cgep-lab" }

Single-line block syntax can include only one argument definition. To
define multiple arguments, use the multi-line block syntax with one
argument definition per line.
```

The lab is dead at step 1. The reader cannot reach the apply, the capture script, the retention check, the destructive test, or the cosign add-on.

## Why this is unintentional (not an expected-error lesson)

This lab does include one intentional expected error, in step 5 (the destructive test, `AccessDenied because object protected by object lock`), and that step is explicitly labeled and explained as the lesson. Step 1 has no such labeling around the variables.tf snippet, it's presented as the working solution. So the comma is a typo, not a teaching moment.

## Fix

Rewrite `project_name` as a multi-line block to match the style already used by `lock_mode` and `retention_days` in the same file:

```hcl
variable "project_name" {
  type    = string
  default = "cgep-lab"
}
```

Smallest possible diff (3 added, 1 removed).

## Verification

With this fix applied locally:

```
$ terraform init
Initializing the backend...
Initializing provider plugins...
- Finding hashicorp/aws versions matching "~> 5.0"...
- Finding hashicorp/random versions matching "~> 3.6"...
...
Terraform has been successfully initialized!
```

## Test plan

- [x] Pasted step 1's variables.tf verbatim, reproduced the `Invalid single-argument block definition` error from `terraform init`
- [x] Applied this fix locally, `terraform init` now succeeds and `terraform validate` reports no issues
- [ ] Will continue running steps 2-6 to surface any further QA findings as separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reformatted Terraform variable declarations to enhance code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->