### PR TITLE
guides 02_05: add missing vault_name output so step 3 substitution works

### DIFF
--- a/guides/02_05_iac_as_compliance_evidence.md
+++ b/guides/02_05_iac_as_compliance_evidence.md
@@ -158,6 +158,14 @@ variable "retention_days" {
 }
 ```
 
+```hcl
+# terraform/outputs.tf
+output "vault_name" {
+  value       = aws_s3_bucket.vault.id
+  description = "S3 bucket name of the evidence vault. Feed this to capture-evidence.sh --vault."
+}
+```
+
 > **GOVERNANCE vs COMPLIANCE.** GOVERNANCE retention can be bypassed by a privileged caller using `--bypass-governance-retention`. COMPLIANCE cannot be bypassed by anyone, including root, until the retention window expires. Use GOVERNANCE for lab work so you can clean up. Use COMPLIANCE for real evidence. The script and the rest of the pattern are identical either way.
 
 ### Step 2 Write `capture-evidence.sh`


### PR DESCRIPTION
## Summary

Step 3 of lab 2.5 reads the vault bucket name out of terraform output, but step 1 never defines a `vault_name` output. Running step 3 verbatim breaks at the AWS layer with a confusing "Invalid bucket name" error.

## What's broken

Step 3 contains:

\`\`\`bash
VAULT=\$(terraform output -raw vault_name)
\`\`\`

Step 1's terraform code (main.tf + variables.tf) does not declare any outputs. So:

1. \`terraform output -raw vault_name\` writes a "No outputs found" warning to its output (visible to the shell, not just stderr).
2. The shell's command substitution captures that multi-line warning text into \`VAULT\`.
3. The next line passes \`"\$VAULT"\` as \`--bucket\` to \`aws s3api put-object\`, which fails parameter validation:

\`\`\`
Parameter validation failed:
Invalid bucket name "...Warning: No outputs found...": Bucket name must
match the regex "^[a-zA-Z0-9.\-_]{1,255}$" or be an ARN ...
\`\`\`

Lab dies at step 3. The error is emitted by AWS, not Terraform, so the reader's first instinct is to debug their AWS profile or the capture script, not the missing output.

## Why this is unintentional

Step 5 ("The destructive test") is the only intentional expected error in this lab, and it is explicitly labeled. Step 3 narrates a smooth happy-path receipt, so the AWS-validation failure is not the lesson.

## Fix

Add a `terraform/outputs.tf` code block to step 1, between the existing variables.tf block and the GOVERNANCE vs COMPLIANCE callout. This matches the main.tf / variables.tf / outputs.tf split already used in lab 2.4.

\`\`\`hcl
# terraform/outputs.tf
output "vault_name" {
  value       = aws_s3_bucket.vault.id
  description = "S3 bucket name of the evidence vault. Feed this to capture-evidence.sh --vault."
}
\`\`\`

8 added lines, 0 removed.

## Verification

With this output defined locally:

\`\`\`
\$ terraform output -raw vault_name
cgep-lab-grc-evidence-vault-5f2c23b9

\$ VAULT=\$(terraform output -raw vault_name)
\$ bash scripts/capture-evidence.sh --workspace ../lab-2-3 --run-id test-001 --vault "\$VAULT" --profile <sandbox>
{"run_id":"test-001","vault":"cgep-lab-grc-evidence-vault-5f2c23b9","key":"runs/test-001/bundle.tar.gz","version_id":"VHu.QuDO5iMrAmUQBr3kIYCpZ92V5Rtd","captured_at_utc":"2026-05-03T18:41:38Z"}
\`\`\`

## Test plan

- [x] Reproduced original failure: ran step 3 verbatim, captured the AWS "Invalid bucket name" error caused by the warning text in \`\$VAULT\`
- [x] Applied this fix locally, ran step 3 verbatim, got the expected single-line receipt JSON
- [x] Verified steps 4 and 5 still work end-to-end after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Infrastructure-as-Code compliance guide to include new Terraform output configuration. Users can now reference the vault identifier when running the compliance evidence capture script for streamlined documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->