### PR TITLE
guides 02_05: write bundle to a stable path so step 6 cosign add-on works

### DIFF
--- a/guides/02_05_iac_as_compliance_evidence.md
+++ b/guides/02_05_iac_as_compliance_evidence.md
@@ -227,7 +227,7 @@ terraform version > "$BUNDLE_DIR/version.txt"
   echo "]"
 } > "$BUNDLE_DIR/manifest.json"
 
-BUNDLE_TGZ="$WORK/bundle-$RUN_ID.tar.gz"
+BUNDLE_TGZ="/tmp/bundle-$RUN_ID.tar.gz"
 ( cd "$WORK" && tar czf "$BUNDLE_TGZ" "bundle-$RUN_ID" )
 
 KEY="runs/$RUN_ID/bundle.tar.gz"


### PR DESCRIPTION
## Summary

Step 6's optional Cosign add-on references a bundle path that the capture script in step 2 never writes. Readers who take the cosign path follow the lab to its end and hit "no such file or directory".

## What's broken

Step 6 contains:

\`\`\`bash
cosign sign-blob --yes --bundle bundle.sig.bundle /tmp/bundle-test-001.tar.gz
\`\`\`

Step 2's capture script writes the bundle here:

\`\`\`bash
WORK=\$(mktemp -d)
trap 'rm -rf "\$WORK"' EXIT
...
BUNDLE_TGZ="\$WORK/bundle-\$RUN_ID.tar.gz"
\`\`\`

Two problems:

1. \`mktemp -d\` lands under \`/var/folders/...\` on macOS or \`/tmp/tmp.XXXXXX\` on Linux. Never \`/tmp/bundle-...\` directly.
2. The \`trap\` deletes \`\$WORK\` on script exit, so the bundle is gone before step 6 ever runs.

Net effect: \`/tmp/bundle-test-001.tar.gz\` does not exist when the reader tries to sign it.

## Fix

Smallest possible change: write the final tarball to a stable, predictable path that matches what step 6 already references.

\`\`\`diff
-BUNDLE_TGZ="\$WORK/bundle-\$RUN_ID.tar.gz"
+BUNDLE_TGZ="/tmp/bundle-\$RUN_ID.tar.gz"
\`\`\`

The \`trap\` still cleans up \`\$WORK\` (the intermediate \`bundle-\$RUN_ID/\` directory and the per-file outputs hashed into \`manifest.json\`), so the temp-cleanup behavior is unchanged. Only the final tarball survives, at the path step 6 expects.

1 line changed.

## Verification

With this fix applied locally:

\`\`\`
\$ bash scripts/capture-evidence.sh --workspace ../lab-2-3 --run-id test-001 --vault \$VAULT --profile <sandbox>
{"run_id":"test-001",...}

\$ ls -la /tmp/bundle-test-001.tar.gz
-rw-r--r-- ... /tmp/bundle-test-001.tar.gz       # exists
\`\`\`

Step 6's \`cosign sign-blob ... /tmp/bundle-test-001.tar.gz\` can now find the file.

## Test plan

- [x] Reproduced original failure: ran the script verbatim, confirmed \`/tmp/bundle-test-001.tar.gz\` does not exist after exit
- [x] Applied this fix locally, ran the script again, confirmed the tarball now persists at the documented path
- [x] Confirmed receipt JSON output (steps 3 and 4 behavior) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated evidence bundle storage location for improved system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->