### PR TITLE
guides 03_03: fix step 2 firewall allow-block comma-in-block syntax

### DIFF
--- a/guides/03_03_writing_compliance_policies_rego.md
+++ b/guides/03_03_writing_compliance_policies_rego.md
@@ -100,7 +100,10 @@ resource "google_compute_firewall" "open_ssh" {
   network       = google_compute_network.demo.name
   direction     = "INGRESS"
   source_ranges = ["0.0.0.0/0"]
-  allow { protocol = "tcp", ports = ["22"] }
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

Step 2's terraform fixture has a `google_compute_firewall.open_ssh` resource whose `allow` block uses single-line syntax with a comma. Terraform's HCL parser rejects it before plan.json can be generated, blocking the entire AC-3 firewall rule path.

## What's broken

\`\`\`hcl
allow { protocol = "tcp", ports = ["22"] }
\`\`\`

Same family of error as the variables.tf bug fixed in #3 (Lab 2.5): single-line HCL blocks accept exactly one argument; multi-arg requires either newlines or whitespace separators (no commas).

\`\`\`
\$ terraform validate
Error: Invalid single-argument block definition

  on main.tf line 58, in resource "google_compute_firewall" "open_ssh":
  58:   allow { protocol = "tcp", ports = ["22"] }

Single-line block syntax can include only one argument definition. To
define multiple arguments, use the multi-line block syntax with one
argument definition per line.
\`\`\`

Without plan.json the reader cannot reach step 8's expected output, particularly the AC-3 firewall deny:

\`\`\`
[AC-3] google_compute_firewall.open_ssh: management port 22 open to 0.0.0.0/0. ...
\`\`\`

## Why this is unintentional

The lab nowhere flags this as an expected error. Step 2 presents the fixture as the working test bed; expected errors in this lab live in step 8 (the `opa eval` denies) and step 9 (none after fix), both of which require a parseable plan.json to reach.

## Fix

Rewrite as a multi-line block, matching every other multi-arg block in this same code (`encryption`, `retention_policy`, etc.):

\`\`\`hcl
allow {
  protocol = "tcp"
  ports    = ["22"]
}
\`\`\`

4 added, 1 removed.

## Verification

With this fix applied locally:

\`\`\`
\$ terraform validate
Success! The configuration is valid.

\$ terraform plan -out=tfplan -var=gcp_project=<sandbox> && terraform show -json tfplan > plan.json
\$ opa eval -d policies -i terraform/plan.json data.compliance.ac3.deny --format=pretty
[
  "[AC-3] google_compute_firewall.open_ssh: management port 22 open to 0.0.0.0/0. Remediation: narrow source_ranges or remove the rule.",
  "[AC-3] google_storage_bucket.bad_public: bucket allows public access. Remediation: ..."
]
\`\`\`

Matches step 8's expected output exactly.

## Test plan

- [x] Reproduced original failure with verbatim fixture (terraform validate errors at line 58)
- [x] Applied this fix locally, validate + plan succeed, plan.json produced
- [x] opa test reports PASS 8/8, opa eval produces all three expected deny sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples in compliance policy guide with improved formatting for enhanced readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->