### PR TITLE
guides 03_03: replace step 2 placeholder bad-bucket bodies with full HCL

### DIFF
--- a/guides/03_03_writing_compliance_policies_rego.md
+++ b/guides/03_03_writing_compliance_policies_rego.md
@@ -86,9 +86,43 @@ resource "google_storage_bucket" "good" {
 }
 
 # Non-compliant cases (each will trip exactly one policy).
-resource "google_storage_bucket" "bad_no_cmek"   { /* same as good, no encryption block */ }
-resource "google_storage_bucket" "bad_public"    { /* uniform_bucket_level_access = false */ }
-resource "google_storage_bucket" "bad_no_labels" { /* no labels */ }
+resource "google_storage_bucket" "bad_no_cmek" {
+  name                        = "${var.gcp_project}-lab33-bad-no-cmek"
+  location                    = "us-central1"
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+
+  labels = {
+    project          = "lab33"
+    environment      = "dev"
+    managed_by       = "terraform"
+    compliance_scope = "cge-p-lab"
+  }
+}
+
+resource "google_storage_bucket" "bad_public" {
+  name                        = "${var.gcp_project}-lab33-bad-public"
+  location                    = "us-central1"
+  uniform_bucket_level_access = false
+
+  encryption { default_kms_key_name = google_kms_crypto_key.key.id }
+
+  labels = {
+    project          = "lab33"
+    environment      = "dev"
+    managed_by       = "terraform"
+    compliance_scope = "cge-p-lab"
+  }
+}
+
+resource "google_storage_bucket" "bad_no_labels" {
+  name                        = "${var.gcp_project}-lab33-bad-no-labels"
+  location                    = "us-central1"
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+
+  encryption { default_kms_key_name = google_kms_crypto_key.key.id }
+}
 
 resource "google_compute_network" "demo" {
   name                    = "lab33-demo"


### PR DESCRIPTION
## Summary

Step 2's three "non-compliant" `google_storage_bucket` resources are placeholder C-style comments rather than real HCL. Pasted verbatim, terraform validate emits six "Missing required argument" errors and the lab dies before plan.json can be generated, so the reader never reaches the lesson in step 8.

## What's broken

\`\`\`hcl
# Non-compliant cases (each will trip exactly one policy).
resource "google_storage_bucket" "bad_no_cmek"   { /* same as good, no encryption block */ }
resource "google_storage_bucket" "bad_public"    { /* uniform_bucket_level_access = false */ }
resource "google_storage_bucket" "bad_no_labels" { /* no labels */ }
\`\`\`

`google_storage_bucket` requires `name` and `location`. Running step 2's `terraform plan`:

\`\`\`
Error: Missing required argument
  on main.tf line 44, in resource "google_storage_bucket" "bad_no_cmek":
  44: resource "google_storage_bucket" "bad_no_cmek"   { ... }
  The argument "name" is required, but no definition was found.

Error: Missing required argument
  ... (×6 total: name + location for each of the three bad resources)
\`\`\`

Step 8's expected output explicitly names each of these three resources:

\`\`\`
[SC-28] google_storage_bucket.bad_no_cmek: ...
[AC-3]  google_storage_bucket.bad_public:  ...
[CM-6]  google_storage_bucket.bad_no_labels: ...
\`\`\`

So the resources are not optional; they have to exist in the plan for the lab to demonstrate its lesson. The placeholder comments leave the reader to invent the bodies themselves with no example.

## Why this is unintentional

The lab's pedagogical promise is "each will trip exactly one policy" (the comment immediately above the placeholders). That promise can only be kept if the lab actually shows the three bodies. The placeholders read as a TODO that didn't get expanded before publishing.

## Fix

Write each bad body in full as "compliant minus exactly one thing". Each body trips exactly one policy:

- `bad_no_cmek`: omit the `encryption {}` block (trips SC-28)
- `bad_public`: set `uniform_bucket_level_access = false` (trips AC-3)
- `bad_no_labels`: omit the `labels = {}` map (trips CM-6)

37 added, 3 removed.

## Verification

With this fix applied locally:

\`\`\`
\$ terraform plan -out=tfplan -var=gcp_project=<sandbox>
Plan: 8 to add, 0 to change, 0 to destroy.

\$ terraform show -json tfplan > plan.json
\$ opa test -v policies/
PASS: 8/8

\$ for ctrl in sc28 ac3 cm6; do
    opa eval -d policies -i terraform/plan.json "data.compliance.\${ctrl}.deny" --format=pretty
  done
[ "[SC-28] google_storage_bucket.bad_no_cmek: ..." ]
[ "[AC-3] google_compute_firewall.open_ssh: ...", "[AC-3] google_storage_bucket.bad_public: ..." ]
[ "[CM-6] google_storage_bucket.bad_no_labels: ..." ]
\`\`\`

Output matches step 8's expected JSON exactly.

## Note

Independent of #6 (firewall allow-block syntax), but both must be applied for step 2's plan to succeed. Either can land first.

## Test plan

- [x] Reproduced original failure: pasted verbatim, terraform validate reports 6 missing-required-argument errors
- [x] Applied this fix locally, terraform plan produces an 8-resource plan
- [x] opa test PASS 8/8, opa eval produces all three expected deny sets
- [x] Step 9 (fix and re-eval) produces empty deny arrays as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced compliance policy guide with expanded Terraform examples. Lab fixtures now include concrete, non-compliant resource definitions that demonstrate how policies should detect and reject various security violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->