### PR TITLE
Lab 4.3 Step 3: add missing Comment-on-PR step to workflow YAML

### DIFF
--- a/guides/04_03_grc_evidence_pipeline.md
+++ b/guides/04_03_grc_evidence_pipeline.md
@@ -221,6 +221,20 @@ jobs:
           name: grc-evidence-${{ github.run_id }}
           path: evidence/
           retention-days: 90
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## GRC gate run #${{ github.run_id }}
+
+            - Conftest: `${{ steps.conftest.outcome }}`
+            - tfsec:    `${{ steps.tfsec.outcome }}`
+            - Evidence: see workflow artifacts (`grc-evidence-${{ github.run_id }}`).
+
+            Lab 4.4 will sign this bundle with Cosign and upload it to the Object Lock vault.
 ```
 
 A few specific choices worth understanding:


### PR DESCRIPTION
## Finding

The Step 3 workflow YAML in `guides/04_03_grc_evidence_pipeline.md` is missing the `Comment on PR` step that both the guide's own architecture diagram and the granted permissions promise.

- Architecture diagram (line 33) lists `Comment on PR with summary`.
- Permissions block (line 129) declares `pull-requests: write  # required to comment on the PR`.
- The actual workflow YAML ends at `Upload evidence artifact` — no comment step.
- The reference workflow at `reference/lab-4-3/.github/workflows/grc-gate.yml` has the `peter-evans/create-or-update-comment@v4` step.

A learner who copies the guide's YAML verbatim:
- gets a `pull-requests: write` permission they don't use,
- never sees the promised PR comment summary,
- can't tell the guide and the reference are out of sync.

## Fix

Pulled the `Comment on PR` step (lines 128-141 of the reference workflow) into the guide YAML, immediately after `Upload evidence artifact`. Body and outcome wiring match the reference exactly.

## Test plan
- [ ] Render the guide and confirm the new step appears at the end of Step 3's YAML
- [ ] On a real PR, confirm the workflow now posts the GRC gate run summary as a PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated evidence pipeline guide to document automated PR comment notifications that include run results and links to evidence artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->