### PR TITLE
Lab 4.3 Step 1: drop demo defaults from reference oidc/main.tf

### DIFF
--- a/reference/lab-4-3/oidc/main.tf
+++ b/reference/lab-4-3/oidc/main.tf
@@ -13,13 +13,11 @@ provider "aws" {
 }
 
 variable "github_org" {
-  type    = string
-  default = "GRCEngClub"
+  type = string
 }
 
 variable "github_repo" {
-  type    = string
-  default = "cgep-app-starter"
+  type = string
 }
 
 # GitHub OIDC provider in this account (one per account).


### PR DESCRIPTION
## Finding

`reference/lab-4-3/oidc/main.tf` ships with hardcoded defaults that point at the demo:

```hcl
variable "github_org" {
  type    = string
  default = "GRCEngClub"
}

variable "github_repo" {
  type    = string
  default = "cgep-app-starter"
}
```

The guide's apply command is:

```bash
terraform apply -var=github_org=YourOrg -var=github_repo=YourRepo
```

So the guide and reference disagree. Under the verbatim-copy rule, a learner who copies `reference/lab-4-3/oidc/main.tf` into their repo and runs `terraform apply` without the `-var=` flags will:

1. Create an IAM role `cgep-grc-gate` in their own AWS account whose trust policy binds to `repo:GRCEngClub/cgep-app-starter:*`.
2. Their own GitHub Actions workflow then fails the OIDC assume-role with `invalid identity token` (the `sub` claim won't match).
3. The role silently trusts the demo's GitHub Actions, not theirs.

The guide already calls out this exact failure mode in its Troubleshooting section but doesn't connect it back to the reference defaults.

## Fix

Drop the `default` lines so the variables are required. This:
- matches the guide's `terraform apply -var=...` instruction,
- aligns reference and guide,
- forces each learner to supply their own org/repo (no silent demo wiring).

## Test plan
- [ ] `cd reference/lab-4-3/oidc && terraform init && terraform plan` -- expect prompts (or error) for `github_org` and `github_repo`
- [ ] `terraform plan -var=github_org=test -var=github_repo=test` succeeds and shows `repo:test/test:*` in the trust policy
- [ ] CI `terraform validate` on the reference still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Terraform module now requires explicit configuration values for GitHub organization and repository settings instead of using predefined defaults. Users must provide these values when deploying the module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->