### PR TITLE
guides 05_02: fix step 1 SSE config single-line nested-block syntax

### DIFF
--- a/guides/05_02_aws_security_services.md
+++ b/guides/05_02_aws_security_services.md
@@ -57,7 +57,11 @@ resource "aws_s3_bucket" "trail" {
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "trail" {
   bucket = aws_s3_bucket.trail.id
-  rule { apply_server_side_encryption_by_default { sse_algorithm = "AES256" } }
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "trail" {


### PR DESCRIPTION
## Summary

Step 1's `aws_s3_bucket_server_side_encryption_configuration` snippet writes the `rule` body on a single line with a nested block inside. HCL rejects this with `Argument definition required` and `terraform init` fails before the lab can build the trail bucket.

## What's broken

\`\`\`hcl
resource "aws_s3_bucket_server_side_encryption_configuration" "trail" {
  bucket = aws_s3_bucket.trail.id
  rule { apply_server_side_encryption_by_default { sse_algorithm = "AES256" } }
}
\`\`\`

Running step 4's \`terraform init\`:

\`\`\`
Error: Argument definition required

  on cloudtrail.tf line 14, ...:
   14:   rule { apply_server_side_encryption_by_default { sse_algorithm = "AES256" } }

A single-line block definition can contain only a single argument.
If you meant to define argument
"apply_server_side_encryption_by_default", use an equals sign to
assign it a value. To define a nested block, place it on a line of
its own within its parent block.
\`\`\`

Lab dies at init. Reader never reaches the apply, so step 5's CloudTrail status check, step 6's findings capture, and the cleanup are all unreachable.

This is the third PR in this family. Same root cause as #3 (Lab 2.5 variables.tf comma) and #6 (Lab 3.3 firewall allow-block comma): single-line HCL block syntax cannot hold more than one argument or any nested block.

## Why this is unintentional

The lab nowhere flags this as an expected error. Step 1 presents the block as the working CloudTrail bucket configuration; the only intentional surprises in the lab are the Step 3 SCP-blocked Config message (explicitly labeled) and the cost callout in the time/cost section.

## Fix

Multi-line the nested block:

\`\`\`hcl
rule {
  apply_server_side_encryption_by_default {
    sse_algorithm = "AES256"
  }
}
\`\`\`

5 added, 1 removed.

## Verification

With this fix applied locally:

\`\`\`
\$ terraform init
Terraform has been successfully initialized!

\$ terraform plan -out=tfplan
Plan: 6 to add, 0 to change, 0 to destroy.

\$ terraform apply -auto-approve tfplan
Apply complete! Resources: 6 added, 0 changed, 0 destroyed.

\$ aws cloudtrail get-trail-status --name cgep-lab-mgmt --region us-east-1 \\
    --query '{IsLogging:IsLogging}'
{ "IsLogging": true }
\`\`\`

## Test plan

- [x] Reproduced original failure: step 1 verbatim, terraform init errors at line 14
- [x] Applied this fix locally, init/plan/apply succeed end-to-end
- [x] Step 5 CloudTrail check returns `IsLogging: true`
- [x] Step 6 captured 50 Security Hub findings (238 KB) into evidence/lab-5-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and readability of AWS security configuration examples in guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->