### PR TITLE
Lab 4.4 Step 3: replace verify-evidence.sh with verbatim reference

### DIFF
--- a/guides/04_04_evidence_chain_of_custody.md
+++ b/guides/04_04_evidence_chain_of_custody.md
@@ -139,51 +139,80 @@ Two scopes only: the vault and its objects. Nothing else.
 
 ```bash
 #!/usr/bin/env bash
-# scripts/verify-evidence.sh <run_id>
+# scripts/verify-evidence.sh
+# Auditor-friendly verification of an evidence bundle in the Object Lock vault.
+#
+# Usage:
+#   verify-evidence.sh <run_id> [--vault <bucket>] [--profile <aws-profile>]
+#
+# Returns 0 on "CHAIN INTACT", non-zero with a specific failure if any of
+# integrity, authenticity, or preservation checks fail.
+
 set -euo pipefail
-RUN_ID="${1:?usage: verify-evidence.sh <run_id> [--vault <bucket>] [--profile <p>]}"
+
+RUN_ID="${1:-}"
+[[ -z "$RUN_ID" ]] && { echo "Usage: $0 <run_id> [--vault <bucket>] [--profile <p>]" >&2; exit 2; }
 shift || true
+
 VAULT="${EVIDENCE_VAULT:-}"
 PROFILE_ARG=""
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --vault)   VAULT="$2"; shift 2 ;;
     --profile) PROFILE_ARG="--profile $2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
   esac
 done
-[[ -z "$VAULT" ]] && { echo "Set --vault or EVIDENCE_VAULT"; exit 2; }
 
-WORK=$(mktemp -d); trap 'rm -rf "$WORK"' EXIT; cd "$WORK"
+[[ -z "$VAULT" ]] && { echo "Set --vault <bucket> or EVIDENCE_VAULT env var" >&2; exit 2; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK"
+
 PREFIX="runs/${RUN_ID}"
 
-aws $PROFILE_ARG s3 cp "s3://${VAULT}/${PREFIX}/" . --recursive \
-  --exclude "*" --include "evidence-*.tar.gz*" --include "receipt.json"
+echo "=== Fetching bundle from s3://${VAULT}/${PREFIX}/ ==="
+aws $PROFILE_ARG s3 cp "s3://${VAULT}/${PREFIX}/" . --recursive --exclude "*" --include "evidence-*.tar.gz*" --include "receipt.json"
 
-BUNDLE=$(ls evidence-*.tar.gz | head -1)
+BUNDLE=$(ls evidence-*.tar.gz 2>/dev/null | head -1)
+[[ -z "$BUNDLE" ]] && { echo "FAIL: bundle not found in vault" >&2; exit 1; }
 
-# 1. Integrity
+echo "=== 1. Integrity (SHA-256) ==="
 EXPECTED=$(cat "${BUNDLE}.sha256")
 ACTUAL=$(shasum -a 256 "${BUNDLE}" | awk '{print $1}')
-[[ "$EXPECTED" == "$ACTUAL" ]] || { echo "FAIL: SHA mismatch"; exit 1; }
+if [[ "$EXPECTED" != "$ACTUAL" ]]; then
+  echo "FAIL: SHA-256 mismatch. expected=$EXPECTED actual=$ACTUAL" >&2; exit 1
+fi
+echo "  OK ($EXPECTED)"
 
-# 2. Authenticity + timestamp
+echo "=== 2. Authenticity + timestamp (Cosign + Sigstore Rekor) ==="
 cosign verify-blob \
   --bundle "${BUNDLE}.sig.bundle" \
   --certificate-identity-regexp '.*' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-  "${BUNDLE}"
+  "${BUNDLE}" >/dev/null
+echo "  OK (Cosign verified, Rekor entry exists)"
 
-# 3. Preservation
+echo "=== 3. Preservation (Object Lock retention) ==="
 RETAIN_UNTIL=$(aws $PROFILE_ARG s3api get-object-retention \
   --bucket "${VAULT}" --key "${PREFIX}/${BUNDLE}" \
-  --query 'Retention.RetainUntilDate' --output text)
+  --query 'Retention.RetainUntilDate' --output text 2>/dev/null || echo "")
+if [[ -z "$RETAIN_UNTIL" ]]; then
+  echo "FAIL: no retention on the object"; exit 1
+fi
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-[[ "$RETAIN_UNTIL" > "$NOW" ]] || { echo "FAIL: retention expired"; exit 1; }
+if [[ "$RETAIN_UNTIL" < "$NOW" ]]; then
+  echo "FAIL: retention has expired ($RETAIN_UNTIL < $NOW)"; exit 1
+fi
+echo "  OK (retain until $RETAIN_UNTIL)"
 
+echo
 echo "CHAIN INTACT for run ${RUN_ID}"
 ```
 
-Three checks, three exits if any fail. The output you want to see at the end is one line: `CHAIN INTACT`.
+Three checks, three named failures, three `OK` lines on success. The final line is `CHAIN INTACT for run <run_id>`, which is also what Step 4's expected output shows.
 
 ### Step 4 Trigger a fresh PR
 


### PR DESCRIPTION
## Finding

The verify script in Step 3 of `guides/04_04_evidence_chain_of_custody.md` is a stripped-down rewrite of `reference/lab-4-4/scripts/verify-evidence.sh`, missing:

- The section header echoes (`=== 1. Integrity (SHA-256) ===` etc.)
- The `OK (...)` confirmation lines after each successful check
- The empty-bundle guard (`[[ -z "$BUNDLE" ]] && { echo "FAIL: bundle not found in vault"...`)
- The `*)` catch-all on the arg parser (silently accepts unknown flags today)
- Separate "no retention set" vs "retention expired" failure paths

Step 4 of the guide then shows the *expected* verify output:

```
=== 1. Integrity (SHA-256) ===
  OK (dd8a473f8c1...)
=== 2. Authenticity + timestamp (Cosign + Sigstore Rekor) ===
Verified OK
  OK (Cosign verified, Rekor entry exists)
=== 3. Preservation (Object Lock retention) ===
  OK (retain until 2026-04-27T18:30:33.696000+00:00)

CHAIN INTACT for run 24963918994
```

That output is *only* what the verbose reference script produces. The guide's stripped script just emits the final `CHAIN INTACT` line. So a learner who copies Step 3 verbatim and runs it cannot reproduce Step 4's promised output.

## Fix

Replace the guide's Step 3 script body with a verbatim copy of `reference/lab-4-4/scripts/verify-evidence.sh`. Adjust the trailing summary sentence ("Three checks, three exits") to mention the OK lines and the final `CHAIN INTACT` line, matching what Step 4 already promises.

Verified verbatim with:
```
diff <guide-script-block> reference/lab-4-4/scripts/verify-evidence.sh
# (empty -- exact match)
```

## Test plan
- [ ] Render the guide and confirm Step 3's script body equals `reference/lab-4-4/scripts/verify-evidence.sh` byte-for-byte
- [ ] Run the script against a real run id and confirm the output matches Step 4's promised output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation to detect missing bundle files and invalid arguments with clearer error messages.
  * Improved integrity check reporting with detailed expected vs. actual mismatches.
  * Refined retention status distinction between missing data and expired retention.

* **Refactor**
  * Reorganized verification output into clearer, sectioned messages for improved readability.
  * Streamlined verification process with suppressed intermediate output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->