### PR TITLE
guides 05_04: document ADC quota project gotcha for orgpolicy.googleapis.com

### DIFF
--- a/guides/05_04_gcp_security_services.md
+++ b/guides/05_04_gcp_security_services.md
@@ -249,6 +249,16 @@ gcloud iam service-accounts keys create /tmp/k.json \
 - **WIF `attribute.repository` condition mismatch.** GitHub's `assertion.repository` is the `OWNER/REPO` literal. Spelling, case, and the slash all matter. If your workflow gets opaque `PERMISSION_DENIED` from `auth@v2`, the condition is wrong.
 - **Data Access logs cost.** In a busy project these can ingest GBs/day. Start with a single service (`storage.googleapis.com`) before turning on KMS and IAM.
 - **`google_org_policy_policy` requires the v2 Org Policy API.** Run `gcloud services enable orgpolicy.googleapis.com` if Terraform errors with `policySpec is not supported`.
+- **`Error 403: ... requires a quota project ... "consumer": "projects/<some-google-id>", "reason": "SERVICE_DISABLED"`** on first apply, despite `orgpolicy.googleapis.com` being enabled on your project. The terraform google provider, when authenticating via ADC (`gcloud auth application-default login`), bills API quota to a Google-managed project number (not your `var.gcp_project`), and that project does not have the API enabled. Setting the ADC quota project alone (`gcloud auth application-default set-quota-project ...`) is NOT enough; the provider needs explicit flags. Add to your `provider "google"` block:
+  ```hcl
+  provider "google" {
+    project               = var.gcp_project
+    region                = "us-central1"
+    user_project_override = true
+    billing_project       = var.gcp_project
+  }
+  ```
+  This tells the provider to bill API quota to your project regardless of ADC's default.
 
 ## Cleanup
 


### PR DESCRIPTION
## Summary

On first \`terraform apply\` with ADC auth (which the prereqs section requires), the lab's Org Policy resources fail with a confusing 403 that names a Google-managed project number the reader doesn't own. The fix is two flags in the terraform google provider config; setting the ADC quota project alone does NOT work. Adding a Troubleshooting entry that names the exact symptoms and shows the fix.

## What's broken

After \`gcloud auth application-default login\` and \`terraform init\`, \`terraform apply\` on the Org Policy resources hits:

\`\`\`
Error 403: Your application is authenticating by using local Application
Default Credentials. The orgpolicy.googleapis.com API requires a quota
project, which is not set by default.

  "@type": "type.googleapis.com/google.rpc.ErrorInfo",
  "metadata": {
    "consumer": "projects/764086051850",
    "service": "orgpolicy.googleapis.com"
  },
  "reason": "SERVICE_DISABLED"
\`\`\`

Two confusing things about this error:

1. \`projects/764086051850\` is NOT \`var.gcp_project\`. It's a Google-managed default ADC quota project the reader doesn't own and can't enable APIs on.
2. \`SERVICE_DISABLED\` reads as "you forgot to enable the API on your project" — but \`orgpolicy.googleapis.com\` IS enabled on \`var.gcp_project\` (per the lab's troubleshooting note about \`gcloud services enable\`). The disabled service is on the unrelated quota project.

A naive reader debugs their own project's API enablement (red herring), or tries \`gcloud auth application-default set-quota-project\` (also doesn't fix it, the provider doesn't honor that for these APIs).

## Fix

Add a troubleshooting entry that names the exact error symptoms and shows the working provider config:

\`\`\`hcl
provider "google" {
  project               = var.gcp_project
  region                = "us-central1"
  user_project_override = true
  billing_project       = var.gcp_project
}
\`\`\`

These two flags tell terraform-provider-google to bill API quota to \`var.gcp_project\` regardless of ADC's default, which makes the orgpolicy.googleapis.com call succeed against the project that actually has the API enabled.

10 added, 0 removed.

## Independence

Independent of #15 (which adds the missing terraform/main.tf scaffolding to step 1). #15 introduces the provider block; this PR documents what flags the provider block needs for ADC-based auth to work with orgpolicy. They land cleanly together or independently.

## Test plan

- [x] Reproduced: ran \`terraform apply\` against the lab's Org Policy resources with ADC auth, got the exact error documented above on first try
- [x] Confirmed \`gcloud auth application-default set-quota-project\` does NOT fix it (still hits the same 403)
- [x] Applied this fix locally (added \`user_project_override = true\` + \`billing_project = var.gcp_project\` to provider block)
- [x] terraform apply now reaches the orgpolicy API with the right project; further behavior depends on the standalone-vs-org issue separately tracked in another PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance addressing Error 403 failures related to quota project and API requirements when using ADC for Org Policy
  * Provides configuration solution to ensure proper billing project allocation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->