### PR TITLE
Lab 6.1 Step 5: add cge-p-minimum profile.json reference

### DIFF
--- a/reference/lab-6-1/profiles/cge-p-minimum/profile.json
+++ b/reference/lab-6-1/profiles/cge-p-minimum/profile.json
@@ -1,0 +1,29 @@
+{
+  "profile": {
+    "uuid": "8b8d450f-6cd4-4341-819e-9597bc5d9bd5",
+    "metadata": {
+      "title": "CGE-P minimum control selection",
+      "last-modified": "2026-04-26T18:00:00.000000+00:00",
+      "version": "1.0.0",
+      "oscal-version": "1.1.3"
+    },
+    "imports": [
+      {
+        "href": "https://raw.githubusercontent.com/usnistgov/oscal-content/main/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_catalog.json",
+        "include-controls": [
+          {
+            "with-ids": [
+              "sc-28",
+              "ac-3",
+              "au-3",
+              "cm-6"
+            ]
+          }
+        ]
+      }
+    ],
+    "merge": {
+      "as-is": true
+    }
+  }
+}


### PR DESCRIPTION
## Finding

Step 5 of `guides/06_01_introduction_to_oscal.md` walks the learner through creating `profiles/cge-p-minimum/profile.json` and shows the full JSON body. Step 6 then runs `trestle profile-resolve` against it. The portfolio submission checklist also requires it as a deliverable.

But there was no corresponding `reference/lab-6-1/profiles/cge-p-minimum/profile.json` in the repo, so:

1. Learners had no reference to compare their profile against (component definition has one, profile didn't).
2. CI's `oscal: trestle validate` job at `.github/workflows/ci.yml` walks `reference/**/{component-definitions,profiles,catalogs}/*.json` -- meaning the profile JSON the guide showed had **never been validated by CI**. If trestle's profile schema rejects something subtle in the example (`merge: { as-is: true }` shape, `with-ids` typing, etc.), no one would know.

## Fix

Add `reference/lab-6-1/profiles/cge-p-minimum/profile.json` with the JSON body from Step 5 of the guide. UUID is a real v4 (`8b8d450f-6cd4-4341-819e-9597bc5d9bd5`), matching the pattern of the existing `component-definition.json` (which uses real UUIDs, not placeholders).

Verified locally:
```
$ trestle init -v && cp ... && trestle validate -f profiles/cge-p-minimum/profile.json
VALID: Model .../profile.json passed the Validator to confirm the model passes all registered validation tests.
```

CI's `oscal` job will now pick this up automatically -- next push will validate it on every PR going forward.

## Test plan
- [ ] CI's `oscal: trestle validate (OSCAL)` job runs and validates the new profile
- [ ] `trestle profile-resolve` against the new profile resolves successfully against the NIST 800-53 Rev 5 catalog (Step 6 of guide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new compliance profile for minimum control selection, enabling configuration of essential security controls aligned with industry standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->