### PR TITLE
Lab 6.1: add evidence link to au-3 implemented-requirement

### DIFF
--- a/guides/05_04_gcp_security_services.md
+++ b/guides/05_04_gcp_security_services.md
@@ -15,7 +15,18 @@ GCP leads with identity and data. Where AWS gives you a flat IAM policy and a Se
 - `gcloud` authenticated for both `gcloud auth login` (interactive) and `gcloud auth application-default login` (Terraform's google provider uses ADC).
 - Terraform `>= 1.6`.
 
-If your project sits inside an Organization and you want to apply Org Policy at the org or folder scope, the same resources below take a different `parent` value. The lab uses project scope so it works in any GCP environment.
+If your project sits inside an Organization and you want to apply Org Policy at the org or folder scope, the same resources below take a different `parent` value. The lab uses project scope, which works for any project that has an Organization parent.
+
+> **Standalone projects (no Organization parent) cannot run Step 1.** Org Policy management requires `roles/orgpolicy.policyAdmin`, which is not grantable on a standalone project. As `roles/owner` you'll get `INVALID_ARGUMENT: Role roles/orgpolicy.policyAdmin is not supported for this resource` when granting, and the apply itself returns `Permission 'orgpolicy.policies.create' denied`. Steps 3 (WIF) and 4 (Audit logs) work fine on standalone projects; only Step 1 + 2 are blocked. Two workarounds:
+>
+> **Option A — Move the project under an Organization (full enforcement).** This is the lab as-designed. Requires owning a domain (~$10-15/yr from any registrar) and setting up a free [Cloud Identity](https://cloud.google.com/identity) account for that domain (Google Workspace also works if you already have it). Cloud Identity creates the GCP Organization automatically. Then move your project under it with the [Resource Manager migrate flow](https://cloud.google.com/resource-manager/docs/project-migration). After that, `roles/orgpolicy.policyAdmin` becomes grantable on the org or the project, and Steps 1 + 2 work as written.
+>
+> **Option B — Standalone-project workaround (per-resource defaults + Rego).** Skip Step 1 + 2 and enforce equivalent guarantees one layer deeper:
+> - For `storage.uniformBucketLevelAccess`: set `uniform_bucket_level_access = true` and `public_access_prevention = "enforced"` on every `google_storage_bucket` resource directly. The Lab 2.4 module already does this; reuse it.
+> - For `iam.disableServiceAccountKeyCreation`: there is no per-SA equivalent at the API. Rely on Lab 3.3's `compliance.cm6` / Conftest gate to flag any `google_service_account_key` resource at PR time, before merge. Detective at PR time instead of preventive at API call time.
+> - For `compute.requireOsLogin`: set `enable-oslogin = "TRUE"` in `metadata` on every `google_compute_instance` resource (or in project metadata via `google_compute_project_metadata`).
+>
+> Option B is weaker (defense-in-depth at the resource and PR layers, not API-layer rejection), but works without changing your project's parent.
 
 ## Estimated time & cost
 

--- a/reference/lab-6-1/component-definitions/compliant-s3-v1/component-definition.json
+++ b/reference/lab-6-1/component-definitions/compliant-s3-v1/component-definition.json
@@ -105,6 +105,13 @@
                     "name": "terraform-resource",
                     "value": "aws_s3_bucket_logging.primary"
                   }
+                ],
+                "links": [
+                  {
+                    "rel": "evidence",
+                    "href": "s3://EVIDENCE_VAULT/runs/LATEST/evidence-LATEST.tar.gz",
+                    "text": "Signed pipeline bundle. terraform/plan.json contains the aws_s3_bucket_logging configuration routing primary access logs to the dedicated log bucket."
+                  }
                 ]
               },
               {


### PR DESCRIPTION
## Finding

In `reference/lab-6-1/component-definitions/compliant-s3-v1/component-definition.json`, the au-3 implemented-requirement was the only one of the four controls with no `links` array.

- sc-28, ac-3, cm-6 each carried at least an evidence link pointing at the pipeline bundle in the Lab 2.5 vault.
- au-3 stopped at terraform-resource props.

The lab requirement (`Verification` section in the guide) is *"At least one evidence URI"* so this was technically valid OSCAL, but it left au-3 inconsistent with its peers and weakened the chain-of-custody story for the access-log control specifically. The signed pipeline bundle already contains the `plan.json` that proves `aws_s3_bucket_logging` is configured -- the URI just wasn't surfaced.

## Fix

Add an evidence link to au-3 with the same template the other controls use (`s3://EVIDENCE_VAULT/runs/LATEST/...`) and a control-specific description.

Verified locally with `trestle validate`:
```
VALID: Model .../component-definition.json passed the Validator
```

## Note on the second commit

This branch contains an extra commit (`fb0fb91 guides 05_04: clarify step 1 prereq for standalone projects, add two workarounds`) that is unrelated to lab 6.1. It came from a parallel Claude Code session working on lab 5.4 in the same git working tree -- our two sessions stomped on each other's HEAD pointer. The relevant commit for THIS PR is just `de90ea1` (the au-3 change). On merge, please squash to that single commit, or cherry-pick `de90ea1` only.

## Test plan
- [ ] CI's `oscal: trestle validate (OSCAL)` job validates the updated component definition
- [ ] Squash/cherry-pick `de90ea1` only on merge so the lab-5-4 commit doesn't land in main from this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifications to GCP security services lab prerequisites, explaining standalone project limitations and providing two workaround options for security enforcement.
  * Enhanced cloud storage component documentation with additional evidence details for logging configuration specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->