### PR TITLE
Adopt the reworked lab guides, add one-time setup and a capstone companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,19 @@
 ## What's here
 
 ```
-guides/        Lab guides, one markdown file per lab
-reference/     Companion Terraform / Rego / shell workspaces, one per lab
+getting-started/  One-time tool and repository setup. Do this before Lab 2.3.
+guides/           Lab guides, one markdown file per lab, plus glossary and resources
+reference/        Companion Terraform / Rego / shell workspaces, one per lab
 ```
+
+## Start here
+
+New to the labs? Do these once, in order, before anything else:
+
+1. [Set up your tools](getting-started/tools.md) — Git Bash, Terraform, AWS CLI
+2. [Set up your repo](getting-started/repo-structure.md) — the `cgep-labs` shape every lab reuses
+
+Then work the labs in order. Unfamiliar terms are in the [Glossary](guides/glossary.md); videos and vendor docs are in [Additional Resources](guides/additional_resources.md).
 
 The guides are the lab. The reference workspaces are the same code in deployable form so you can run it and see it work, then build your own version in your capstone repo.
 
@@ -25,7 +35,8 @@ The guides are the lab. The reference workspaces are the same code in deployable
 | [5.2](guides/05_02_aws_security_services.md) | AWS Security Services Baseline | AWS |
 | [5.4](guides/05_04_gcp_security_services.md) | GCP Security Services Baseline | GCP |
 | [6.1](guides/06_01_introduction_to_oscal.md) | Introduction to OSCAL | Cloud-agnostic |
-| [7.1](guides/07_01_capstone_brief.md) | Capstone Brief | AWS |
+| [7.1](guides/07_01_capstone_brief.md) | Capstone Brief (the graded contract) | AWS |
+| [7.2](guides/07_02_capstone_companion.md) | Capstone Companion (how to assemble it) | AWS |
 
 The labs alternate between AWS and GCP on purpose. The compliance-by-default pattern is cloud-agnostic; doing it in two providers makes that obvious.
 

--- a/getting-started/repo-structure.md
+++ b/getting-started/repo-structure.md
@@ -1,0 +1,129 @@
+# Set up your repo
+
+This is the `cgep-labs` repository shape every later lab reuses. Do it once, before Lab 2.3.
+
+Prerequisite: [Set up your tools](tools.md).
+
+This is the part that tripped up the last cohort, so we're going to be explicit. Every lab in this course drops files into the same repository, in the same shape. Get the shape right once, here, and the rest of the course just slots into it. Get it wrong, and you'll spend later labs hunting for files that aren't where the guide expects.
+
+## The mental model
+
+You're building **one repository** called `cgep-labs`. It lives in two places at once:
+
+- **On your machine**, as a folder you work in.
+- **On GitHub**, as the published copy your instructor reviews.
+
+These aren't two different things. When you `git push`, your local folder becomes the GitHub copy, file for file. So when a guide talks about "the version that gets evaluated," it means your `cgep-labs` repo on GitHub, which is just your local folder after you've pushed it. There's no separate "submission" copy to assemble.
+
+(Your final capstone is a separate repository later on, a fork of the starter app. It uses this exact same structural discipline, so the habits you build here carry straight over.)
+
+## Create the structure
+
+Pick a home for your work (your Documents folder is fine) and build the skeleton — including the empty files this lab will fill in. From your terminal:
+
+```bash
+mkdir -p cgep-labs
+cd cgep-labs
+
+# Repo-wide folders every later lab reuses
+mkdir -p terraform/primitives terraform/modules scripts evidence
+
+# This lab's empty files (matches the diagram below)
+mkdir -p terraform/primitives/compliant-s3 evidence/lab-2-3
+touch README.md .gitignore \
+  terraform/primitives/compliant-s3/main.tf \
+  terraform/primitives/compliant-s3/variables.tf \
+  terraform/primitives/compliant-s3/outputs.tf \
+  terraform/primitives/compliant-s3/README.md
+
+# Confirm the shape
+find terraform/primitives/compliant-s3 evidence/lab-2-3 -type f | sort
+```
+
+Here's what you just created and what each folder is for:
+
+```
+cgep-labs/                        ← repository root. Everything lives under here.
+│
+├── README.md                     ← what this repo is (you'll create this below)
+├── .gitignore                    ← tells Git which files NOT to publish
+│
+├── terraform/                    ← all your infrastructure-as-code
+│   ├── primitives/               ← standalone units you deploy directly
+│   │   └── compliant-s3/         ← THIS lab lives here
+│   │       ├── main.tf
+│   │       ├── variables.tf
+│   │       ├── outputs.tf
+│   │       └── README.md
+│   └── modules/                  ← reusable modules (Lab 2.4 fills this in)
+│
+├── scripts/                      ← shared scripts (Lab 2.5 adds one here)
+│
+└── evidence/                     ← captured proof, one folder per lab
+    └── lab-2-3/                  ← THIS lab's evidence lands here
+        ├── plan.json             ← filled in when you capture evidence
+        └── state.json            ← filled in when you capture evidence
+```
+
+Two ideas are doing all the work in this layout, and they're worth saying out loud:
+
+- **Code and evidence are separate.** Your Terraform lives under `terraform/`. The proof you capture lives under `evidence/`, named by lab. A reviewer can find every artifact for Lab 2.3 in `evidence/lab-2-3/` without digging through your code. This separation is also why a later lab can capture evidence *from* an earlier lab's workspace; the workspace is always `terraform/.../<thing>`, and the evidence always lands in `evidence/lab-X-Y/`.
+- **`primitives/` vs `modules/`.** A primitive is something you deploy as-is. A module is a reusable template that other code calls. This lab builds a primitive. Lab 2.4 builds your first module. Keeping them in separate folders keeps that distinction visible.
+
+## Add a `.gitignore` before you commit anything
+
+This step matters more than it looks. When Terraform runs, it creates files you must **not** publish to GitHub:
+
+- `terraform.tfstate` and its backups: Terraform's record of what it built. It can contain sensitive values, and it's specific to your machine.
+- The `.terraform/` directory: hundreds of megabytes of downloaded provider plugins. No one needs your copy.
+- `.terraform.lock.hcl`: the provider dependency lock. It's useful in a long-lived production repo, but it's not part of this course's submission, so we keep it out to match the checklist exactly.
+- `tfplan`: the saved binary plan from `terraform plan -out=tfplan`. It's scratch input for `apply`, not an artifact a reviewer wants.
+- `*.tfvars`: where people often put secrets.
+
+A `.gitignore` file tells Git to skip these. Open the empty **`.gitignore`** at the repo root (created in the scaffold above) and paste this in, or overwrite it from the terminal:
+
+```bash
+cat > .gitignore << 'EOF'
+# Terraform working files (never publish these)
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+*.tfvars
+tfplan
+*.tfplan
+crash.log
+
+# OS noise
+.DS_Store
+EOF
+```
+
+Notice what this does *not* ignore: your `evidence/` folder. The files in there are named `plan.json` and `state.json`, not `*.tfstate`, so they sail right past these rules. That's deliberate. The live state file is private working data; the evidence snapshot is the artifact you *want* reviewed. Same data, captured for two different purposes, treated two different ways. Understanding that distinction is half of what this course is about.
+
+## Initialize Git and push to GitHub
+
+```bash
+git init
+git add .
+git commit -m "Scaffold cgep-labs repo structure"
+```
+
+Then create an empty repository named `cgep-labs` on GitHub (don't let GitHub add a README or .gitignore, since you already have them), and connect it:
+
+```bash
+git remote add origin https://github.com/<your-username>/cgep-labs.git
+git branch -M main
+git push -u origin main
+```
+
+From now on, finishing a lab means committing your new files and running `git push`. That published copy is what gets reviewed.
+
+---
+
+
+---
+
+## What's next
+
+Continue with [Lab 2.3: Building Your First Compliant Resource](../guides/02_03_first_compliant_resource.md). Unfamiliar terms? See the [Glossary](../guides/glossary.md). For videos and official docs, see [Additional Resources](../guides/additional_resources.md).

--- a/getting-started/tools.md
+++ b/getting-started/tools.md
@@ -1,0 +1,89 @@
+# Set up your tools
+
+Complete this once before any lab. It covers the tools every guide assumes.
+
+If you already have Git Bash (or a native bash shell), Terraform, and the AWS CLI working, continue to [Set up your repo](repo-structure.md).
+
+Skip ahead to Part 2 if you already have Git Bash, Terraform, and the AWS CLI working. If any of those is new to you, read on. Getting this right once saves you from a dozen confusing errors later.
+
+## The tools you need, and where to get them
+
+Every link below points at the official source. Don't install these from random blog mirrors; cloud tooling is exactly the kind of thing you want to get from the vendor.
+
+| Tool | What it does | Official download |
+|---|---|---|
+| **Git for Windows (Git Bash)** | Gives Windows a Unix-style terminal so every command in these guides runs as written. Mac and Linux already have this. | https://git-scm.com/download/win |
+| **Terraform** | Turns your `.tf` files into real cloud resources. The core of every IaC lab. | https://developer.hashicorp.com/terraform/install |
+| **AWS CLI v2** | Lets you talk to AWS from the terminal, and lets Terraform authenticate. | https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html |
+
+Three more tools show up in later labs. You don't need them today, but here's where they live so you can install them ahead of time if you like:
+
+| Tool | First used in | Official download |
+|---|---|---|
+| **Google Cloud CLI (`gcloud`)** | Lab 2.4 (GCP) | https://cloud.google.com/sdk/docs/install |
+| **OPA (Open Policy Agent)** | Lab 3.3 (Rego policies) | https://www.openpolicyagent.org/docs and releases at https://github.com/open-policy-agent/opa/releases |
+| **Cosign** | Lab 2.5 / Lab 4.4 (signing evidence) | https://docs.sigstore.dev/cosign/system_config/installation/ and releases at https://github.com/sigstore/cosign/releases |
+
+## Windows users: set up Git Bash
+
+These guides are written in bash, the command language that ships with Mac and Linux. On Windows, the closest thing you'll already have is PowerShell, but PowerShell uses different syntax for a lot of these commands. Rather than translate every command, we standardize the whole cohort on **Git Bash**, which gives you a real bash terminal on Windows. When a guide says to run `mkdir -p terraform/primitives/compliant-s3`, you'll be able to paste it exactly as written.
+
+1. Download and run the installer from https://git-scm.com/download/win. Accepting the default options at every screen is fine.
+2. After it installs, you'll have a "Git Bash" entry in your Start menu. That's your terminal for these labs.
+
+**Make Git Bash your default terminal in VS Code.** If you use VS Code (recommended), tell it to open Git Bash instead of PowerShell so your integrated terminal matches the guides:
+
+- Open the Command Palette with `Ctrl+Shift+P`.
+- Type `Terminal: Select Default Profile` and select it.
+- Choose **Git Bash** from the list.
+- Open a new terminal (`` Ctrl+` ``). It should now be a Git Bash prompt.
+
+**Run this one config command before you do anything else.** Windows and Unix disagree about how lines end in text files, and that disagreement can silently corrupt shell scripts you'll write in later labs. This setting tells Git to leave your files alone:
+
+```bash
+git config --global core.autocrlf input
+```
+
+### Git Bash quirks worth knowing now
+
+You probably won't hit these in this lab, but they cause real head-scratching later, so file them away:
+
+- **Mangled paths.** Git Bash tries to be helpful by converting anything that looks like a Unix path (starting with `/`) into a Windows path. That's great for filenames and wrong for things like S3 keys, ARNs, or `file:///...` arguments. If a command fails with a path that looks half-rewritten, run it again with `MSYS_NO_PATHCONV=1` in front, for example `MSYS_NO_PATHCONV=1 aws s3api ...`.
+- **`sha256sum` vs `shasum`.** Git Bash ships `sha256sum`. macOS ships `shasum -a 256`. They compute the same hash; later lab scripts detect which one you have automatically.
+
+## Mac and Linux users
+
+You already have bash, so there's nothing extra to install for the terminal itself. Install Terraform and the AWS CLI from the official links above. On Mac, Homebrew is the easy path: `brew install terraform awscli`. On Ubuntu, the install pages above include `apt` instructions.
+
+## Confirm everything works
+
+Open your terminal (Git Bash on Windows) and run each of these. You want a version number back from each one, not a "command not found":
+
+```bash
+git --version
+terraform version
+aws --version
+```
+
+If any command isn't found, the tool either didn't install or isn't on your PATH. The official install pages above each have a "verify your installation" section that walks through fixing PATH issues for your OS.
+
+## Connect the AWS CLI to your account
+
+Terraform doesn't log into AWS by itself. It borrows credentials from the AWS CLI. You need a working CLI profile before Terraform will do anything.
+
+- If your sandbox uses a plain access key, run `aws configure` and paste in your key, secret, and default region (`us-east-1` for this lab).
+- If your sandbox uses AWS SSO (also called IAM Identity Center), run `aws configure sso` and follow the browser prompts.
+
+Commands in this guide (and later labs) use `--profile default` so you can paste them as-is if you kept the usual AWS CLI profile name. **If you named your profile something else during `aws configure` or `aws configure sso`, replace `default` with that name** wherever you see `--profile default`.
+
+Confirm the CLI can reach your account:
+
+```bash
+aws sts get-caller-identity --profile default
+```
+
+A JSON blob with your account ID means you're connected.
+
+---
+
+Next: [Set up your repo](repo-structure.md), then [Lab 2.3](../guides/02_03_first_compliant_resource.md).

--- a/guides/02_03_first_compliant_resource.md
+++ b/guides/02_03_first_compliant_resource.md
@@ -1,63 +1,95 @@
 # Lab 2.3: Building Your First Compliant Resource (AWS S3)
 
-You've spent enough time in spreadsheets pretending they're controls. This lab ends that. You'll write Terraform for a single S3 bucket that satisfies five NIST 800-53 controls, SC-28, AU-3, AU-6, CM-6, AC-3, and produce machine-readable evidence of every one. No screenshots.
+Welcome to the first hands-on lab. This is the one that turns the ideas from the lectures into something running in a real cloud account, so we're going to move slowly and explain the *why* behind each step, not just the commands.
+
+A quick word on who's in the room. Some of you come from GRC and have written plenty of controls but never touched Terraform. Some of you come from cloud or DevOps and have deployed plenty of infrastructure but never had to prove a control to an auditor. This lab is built for both of you. The GRC folks will recognize the control language and learn how it gets enforced in code. The technical folks will recognize the tooling and learn why the tagging, logging, and evidence steps aren't busywork. By the end, everyone will have built the same thing: one S3 bucket that satisfies five real NIST 800-53 controls, plus machine-readable proof that it does.
+
+No screenshots. That's the theme of the whole course, and it starts here.
+
+## What you'll build, in plain language
+
+You'll use Terraform to create an Amazon S3 bucket (cloud storage) that is locked down to a security baseline, and a second bucket that records who accessed the first one. Then you'll capture a file that proves the baseline is in place. That proof file is the thing an auditor would accept instead of a screenshot, because it comes straight from the system and can't be faked by cropping a browser window.
+
+The five controls you'll satisfy, translated out of NIST-speak:
+
+| Control | What it means in plain terms | Where it lives in your code |
+|---|---|---|
+| **SC-28** | Data is encrypted while it sits in storage, so a stolen disk is useless. | `aws_s3_bucket_server_side_encryption_configuration` |
+| **AC-3** | Nobody on the public internet can reach the bucket. | `aws_s3_bucket_public_access_block` (four flags, all `true`) |
+| **AU-3** | There's a record of who accessed the data. | `aws_s3_bucket_logging` writing to the log bucket |
+| **AU-6** | Those records are kept somewhere you can actually review. | the separate log bucket |
+| **CM-6** | The resource is set to an approved configuration, and that's labeled and enforced. | required tags + versioning |
+
+You don't need to memorize the control IDs. You need to be able to point at a line of code and say which control it enforces, because that's the muscle every later lab builds on.
 
 ## Learning objectives
 
-- Express NIST 800-53 controls as Terraform resources, citing each control where it's enforced.
+- Express NIST 800-53 controls as Terraform resources, and cite each control where it's enforced.
 - Capture pre- and post-deploy compliance evidence as JSON instead of screenshots.
-- Build a primitive that the rest of the CGE-P labs will reuse and verify automatically.
+- Stand up the repository structure that every later lab (and your capstone) will reuse.
+- Build a primitive that the rest of the course verifies automatically.
 
-## Prerequisites
+## Time and cost
 
-- AWS account with permissions to create S3 buckets in `us-east-1` (administrator-equivalent on a sandbox account is easiest).
-- Terraform `>= 1.6` (`terraform version`).
-- AWS CLI v2 with a working profile. Examples below use `--profile <your-sandbox>`; substitute your profile name. If your profile uses AWS SSO, export credentials with `eval "$(aws configure export-credentials --profile <your-sandbox> --format env)"` before running Terraform.
-- 30–45 minutes of focus.
+- Time: 45 to 60 minutes the first time, closer to 20 minutes on a repeat. Add 30 to 45 minutes if you have not done the one-time setup below yet.
+- Cost: under one cent if you destroy the same day. Empty S3 buckets cost nothing to sit there. You pay fractions of a cent for the handful of API calls Terraform makes.
 
-## Estimated time & cost
+---
 
-- Time: 30–45 min the first time, 10 min on repeats.
-- Cost: under $0.01 if you destroy same-day. Empty S3 buckets have no idle cost. You'll pay fractions of a cent for the API calls Terraform makes.
+## Before you begin
 
-## Architecture
+If this is your first lab, set up [your tools](../getting-started/tools.md) and [your repo](../getting-started/repo-structure.md) first. Together they take about 30 to 45 minutes, once, and every later lab assumes they're done. You need Git Bash (or a native bash shell), Terraform `>= 1.6`, a working AWS CLI v2 profile, and a pushed `cgep-labs` repository.
 
-One primary bucket holds your data. A separate log bucket receives S3 server access logs from the primary. Both buckets enforce the same baseline: AES-256 server-side encryption, versioning, full public access block, and the four required compliance tags.
+The rest of this guide assumes that's in place. Commands below use `--profile default`; if you named your AWS CLI profile something else, substitute it.
+
+# Build the compliant bucket
+
+Now the actual lab. Make sure you're in the repo root (`cgep-labs`) and your AWS CLI profile is working.
+
+## How the pieces fit
+
+You're building two buckets. The **primary bucket** is where data would go. The **log bucket** quietly records every access to the primary one. Both buckets enforce the same baseline: encryption, versioning, a full public-access block, and the required compliance tags.
 
 ```
-                ┌──────────────────────────┐
-   default_tags │  Project / Environment / │
-   (provider)   │  ManagedBy / ComplianceScope
-                └──────────────┬───────────┘
-                               │
-            ┌──────────────────┴───────────────────┐
-            ▼                                      ▼
-  ┌────────────────────┐               ┌─────────────────────┐
-  │ aws_s3_bucket      │   logs (AU-3) │ aws_s3_bucket (log) │
-  │ primary            │──────────────▶│ ACL: log-delivery   │
-  │ AES256 (SC-28)     │               │ AES256              │
-  │ versioning ON      │               │ public-block (AC-3) │
-  │ public-block (AC-3)│               └─────────────────────┘
-  └────────────────────┘
+                ┌──────────────────────────────┐
+   default_tags │  Project / Environment /     │
+   (provider)   │  ManagedBy / ComplianceScope │
+                └───────────────┬──────────────┘
+                                │  applied automatically to everything
+             ┌──────────────────┴───────────────────┐
+             ▼                                       ▼
+   ┌────────────────────┐                ┌──────────────────────┐
+   │ primary bucket     │  access logs   │ log bucket           │
+   │ AES256  (SC-28)    │ ──────────────▶│ receives logs (AU-3) │
+   │ versioning ON      │                │ AES256               │
+   │ public-block (AC-3)│                │ public-block (AC-3)  │
+   └────────────────────┘                └──────────────────────┘
 ```
 
-## Step-by-step walkthrough
+The `default_tags` block at the top is a small trick that pays off all course long: it stamps the four required compliance tags onto every taggable resource automatically, so you can't forget them on one resource and quietly fail CM-6.
 
-### Step 1 Create the project structure
+### Why we bother capturing evidence at all
+
+In production, you don't get to walk an auditor through your AWS console. They want proof that's hard to fake and easy to re-check: a file that came out of the system, that anyone can run the same command to reproduce. `terraform show -json` gives you exactly that. The bucket you build today is small. The habit of capturing its configuration as JSON is the whole point, and it's the thread that runs through every remaining lab.
+
+## Step 1: Open the lab folder
+
+You already created the empty files during repo setup. Move into that folder so relative Terraform commands land in the right place:
 
 ```bash
-mkdir -p terraform/primitives/compliant-s3 && cd terraform/primitives/compliant-s3
-touch main.tf variables.tf outputs.tf README.md
+# from the repo root (cgep-labs)
+cd terraform/primitives/compliant-s3
+ls   # expect: main.tf  variables.tf  outputs.tf  README.md
 ```
 
-This is the directory shape every lab will reuse. By Ch 7 your capstone repo will have a dozen of these.
+You're now sitting inside `terraform/primitives/compliant-s3/`, which is where this lab's `.tf` files live. The three `.tf` files split the work the way every Terraform project does: `main.tf` for the resources, `variables.tf` for the inputs, `outputs.tf` for the values you want back out.
 
-### Step 2 Write the base bucket + tags
+## Step 2: Write the base bucket and tags
 
-Open `main.tf` and start with the provider configuration. The `default_tags` block makes the four required compliance tags non-optional, every taggable resource you create from this provider gets them automatically.
+Open **`terraform/primitives/compliant-s3/main.tf`** (the empty file from the scaffold). Start with the provider configuration. The `default_tags` block is what makes the four required compliance tags non-optional.
 
 ```hcl
-# main.tf
+# terraform/primitives/compliant-s3/main.tf
 terraform {
   required_version = ">= 1.6"
   required_providers {
@@ -96,10 +128,12 @@ resource "aws_s3_bucket" "primary" {
 }
 ```
 
-Now `variables.tf`. Validation blocks turn typos into plan-time failures.
+The `random_id` deserves a note, because it prevents a very common first-day error. **S3 bucket names are globally unique across all of AWS**, not just your account. If you and three classmates all try to create `cgep-lab-dev-data`, only the first one wins and the rest get an error. The random suffix sidesteps that by tacking a few unique characters onto every name.
+
+Now open **`terraform/primitives/compliant-s3/variables.tf`**. These `validation` blocks are doing compliance work: they turn a typo into a clear failure at plan time, before anything is built, instead of a confusing error halfway through deployment.
 
 ```hcl
-# variables.tf
+# terraform/primitives/compliant-s3/variables.tf
 variable "project_name" {
   type        = string
   description = "Short project identifier. Becomes part of bucket names and the Project tag."
@@ -125,12 +159,12 @@ variable "bucket_suffix" {
 }
 ```
 
-### Step 3 Add encryption, versioning, public access block
+## Step 3: Add encryption, versioning, and the public access block
 
-Three resources, three controls.
+Three resources, three controls. Append these to the same **`terraform/primitives/compliant-s3/main.tf`** you started in Step 2.
 
 ```hcl
-# main.tf (continued)
+# terraform/primitives/compliant-s3/main.tf (continued)
 
 # SC-28: Protection of information at rest.
 # AES-256 keeps this lab simple. The commented block below shows how you'd
@@ -171,14 +205,14 @@ resource "aws_s3_bucket_public_access_block" "primary" {
 }
 ```
 
-All four flags must be `true`. Three is not enough. AWS treats them as independent doors.
+All four flags in that last block must be `true`. AWS treats them as four independent doors into the bucket, and leaving any one open defeats the purpose. Three out of four is not "mostly compliant"; it's a public bucket waiting to happen. This is the kind of thing AC-3 exists to catch.
 
-### Step 4 Add the log bucket and wire up access logging
+## Step 4: Add the log bucket and turn on access logging
 
-The log bucket needs its own encryption and public-access-block, plus an ACL allowing the S3 log delivery group to write into it. Define it before the `aws_s3_bucket_logging` that points at it.
+The log bucket needs its own encryption and public-access block, plus a small ACL that lets AWS's log-delivery service write into it. The order matters here, which is why there's a `depends_on`. Append to **`terraform/primitives/compliant-s3/main.tf`**:
 
 ```hcl
-# main.tf (continued)
+# terraform/primitives/compliant-s3/main.tf (continued)
 
 # AU-3 / AU-6: Content of audit records + audit review.
 resource "aws_s3_bucket" "log" {
@@ -220,10 +254,12 @@ resource "aws_s3_bucket_logging" "primary" {
 }
 ```
 
-Now `outputs.tf`. The `encryption_algorithm` output is a deliberate piece of evidence, it's the SC-28 attestation in machine-readable form.
+That last resource, `aws_s3_bucket_logging`, is the line that actually wires AU-3. It tells the primary bucket to send its access logs to the log bucket. Without it you'd have two buckets and no audit trail between them.
+
+Now open **`terraform/primitives/compliant-s3/outputs.tf`**. Outputs are values Terraform hands back after it runs. Most of these are identifiers, but `encryption_algorithm` is something more interesting: it's deliberate evidence. It's the SC-28 attestation, in a form a machine can read and a policy can later check.
 
 ```hcl
-# outputs.tf
+# terraform/primitives/compliant-s3/outputs.tf
 output "bucket_arn"     { value = aws_s3_bucket.primary.arn }
 output "bucket_name"    { value = aws_s3_bucket.primary.id }
 output "log_bucket_arn" { value = aws_s3_bucket.log.arn }
@@ -237,17 +273,26 @@ output "encryption_algorithm" {
 }
 ```
 
-> **Why the `one(...)` expression:** Terraform represents the `rule` block of `aws_s3_bucket_server_side_encryption_configuration` as a *set*, not a list. Sets are not index-addressable. The `for` expression flattens the single rule into a list, then `one()` extracts the lone element, failing loudly if there's ever more than one. This is the kind of thing that catches you off-guard the first time and never again.
+> **Why the `one(...)` expression looks odd.** Terraform represents that `rule` block as a *set*, not a list, and sets can't be accessed by index. The `for` expression flattens the single rule into a list, and `one()` pulls out the lone element, failing loudly if there's ever somehow more than one. It catches everyone off-guard the first time. Once you've seen it, you'll recognize the pattern whenever a nested block is modeled as a set.
 
-### Step 5 terraform init / plan / apply
+## Step 5: Initialize, plan, and apply
 
-If you're using AWS SSO, export your credentials so Terraform's AWS provider can use them:
+These three Terraform commands are the core loop you'll run for the rest of the course, so here's what each one does:
+
+- `terraform init` downloads the AWS and random providers into `.terraform/` (the folder your `.gitignore` skips). Run it once per workspace, or any time you change providers.
+- `terraform validate` checks your `.tf` files for syntax and obvious mistakes.
+- `terraform plan` works out exactly what it would create, without creating anything. The `-out=tfplan` saves that plan to a file.
+- `terraform apply` builds it. Passing the saved `tfplan` means it builds precisely what you just reviewed, no surprises.
+
+Two of those steps need input from you. Look back at `variables.tf`: `project_name` and `environment` have no `default`, on purpose. They're the values stitched into your bucket names and compliance tags, so Terraform makes you choose them.
+
+If your sandbox uses AWS SSO, export your credentials first so Terraform's AWS provider can use them (the provider doesn't always read SSO config the way the CLI does):
 
 ```bash
-eval "$(aws configure export-credentials --profile <your-sandbox> --format env)"
+eval "$(aws configure export-credentials --profile default --format env)"
 ```
 
-Then run the standard cycle:
+Then run the loop:
 
 ```bash
 terraform init
@@ -256,7 +301,18 @@ terraform plan -out=tfplan
 terraform apply -auto-approve tfplan
 ```
 
-Expected tail of `apply`:
+> **Heads up: `plan` will stop and ask you for two values.** Because `project_name` and `environment` have no defaults, Terraform prompts for each one by name before it finishes the plan. Read the label on each prompt and type the matching value — `cgep-lab` for `project_name`, `dev` for `environment`. Don't go by order; Terraform asks by what's missing, not by how you defined them. `environment` is validated, so it has to be `dev`, `staging`, or `prod`. Those two values are exactly what make your bucket come out as `cgep-lab-dev-data-<random>`, the expected output below. (`apply` reuses the saved `tfplan`, so it won't ask again.)
+
+If you'd rather not be prompted, pass the same values as flags instead and Terraform runs straight through:
+
+```bash
+terraform init
+terraform validate
+terraform plan -out=tfplan -var="project_name=cgep-lab" -var="environment=dev"
+terraform apply -auto-approve tfplan
+```
+
+You should see something like this at the end of `apply`:
 
 ```
 Apply complete! Resources: 11 added, 0 changed, 0 destroyed.
@@ -269,33 +325,51 @@ encryption_algorithm = "AES256"
 log_bucket_arn = "arn:aws:s3:::cgep-lab-dev-logs-XXXXXXXX"
 ```
 
-Eleven resources, four outputs. Your bucket suffix will differ.
+Eleven resources, four outputs. Your suffix will be different from anyone else's, which is the random_id doing its job.
 
-### Step 6 Capture evidence with `terraform show -json`
+## Step 6: Capture your evidence
+
+Here's where the last cohort got tangled up, so read this carefully. You're going to capture two JSON files, and they belong in the repo-root `evidence/lab-2-3/` folder, **not** inside this Terraform directory.
+
+You're currently inside `terraform/primitives/compliant-s3/`. To write up to the repo root, the path climbs back three levels: `../` to `primitives/`, `../../` to `terraform/`, `../../../` to the repo root. So:
 
 ```bash
-mkdir -p evidence
-terraform show -json tfplan > evidence/plan.json
-terraform show -json        > evidence/state.json
+mkdir -p ../../../evidence/lab-2-3
+terraform show -json tfplan > ../../../evidence/lab-2-3/plan.json
+terraform show -json        > ../../../evidence/lab-2-3/state.json
 ```
 
-Open `evidence/state.json` and find your bucket. You'll see SC-28 (`server_side_encryption_configuration[].rule[].apply_server_side_encryption_by_default[].sse_algorithm = "AES256"`), AC-3 (`public_access_block`'s four `true`s), CM-6 (the four tags), AU-3 (`logging[].target_bucket`).
+If counting the `../` makes you nervous, here's the same thing done from the repo root instead, which some people find clearer:
 
-`terraform show -json` output IS machine-readable compliance evidence. No screenshots needed.
+```bash
+# from cgep-labs (the repo root)
+mkdir -p evidence/lab-2-3
+terraform -chdir=terraform/primitives/compliant-s3 show -json tfplan > evidence/lab-2-3/plan.json
+terraform -chdir=terraform/primitives/compliant-s3 show -json        > evidence/lab-2-3/state.json
+```
 
-## Verification
+Either way, open `evidence/lab-2-3/state.json` and find your bucket. Reading it, you can point at the evidence for every control you set out to enforce:
 
-Run these three commands. Substitute your bucket name (output of `terraform output -raw bucket_name`).
+- **SC-28** at `server_side_encryption_configuration[].rule[].apply_server_side_encryption_by_default[].sse_algorithm = "AES256"`
+- **AC-3** in `public_access_block`, where all four flags read `true`
+- **CM-6** in the four tags
+- **AU-3** at `logging[].target_bucket`
+
+That file is machine-readable compliance evidence. It's the thing you hand over instead of a screenshot, and in Lab 3 a policy will read it automatically.
+
+## Verify it from the outside
+
+The evidence above comes from Terraform's own view of the world. It's worth confirming the same facts by asking AWS directly, the way an auditor's tool would. Substitute your bucket name:
 
 ```bash
 BUCKET=$(terraform output -raw bucket_name)
 
-aws s3api get-bucket-encryption    --profile <your-sandbox> --bucket "$BUCKET"
-aws s3api get-bucket-versioning    --profile <your-sandbox> --bucket "$BUCKET"
-aws s3api get-public-access-block  --profile <your-sandbox> --bucket "$BUCKET"
+aws s3api get-bucket-encryption    --profile default --bucket "$BUCKET"
+aws s3api get-bucket-versioning    --profile default --bucket "$BUCKET"
+aws s3api get-public-access-block  --profile default --bucket "$BUCKET"
 ```
 
-Expected output (abridged):
+Expected output, trimmed:
 
 ```json
 { "ServerSideEncryptionConfiguration": { "Rules": [ {
@@ -311,51 +385,90 @@ Expected output (abridged):
 } }
 ```
 
-If any of those three are missing or wrong, the bucket isn't compliant. Fix the Terraform, re-apply, re-verify.
+If any of the three comes back missing or wrong, the bucket isn't compliant. Fix the Terraform, re-apply, re-verify. That loop, fix the code rather than fix the resource by hand, is the production-correct instinct: in real life the code is the source of truth, and clicking around the console to patch something just means it drifts back the next time Terraform runs.
 
-## Portfolio submission checklist
+---
 
-Commit to your capstone repo:
+## Commit your work
 
-- `terraform/primitives/compliant-s3/main.tf`
-- `terraform/primitives/compliant-s3/variables.tf`
-- `terraform/primitives/compliant-s3/outputs.tf`
-- `terraform/primitives/compliant-s3/README.md`, one paragraph: "this module enforces SC-28, AU-3, AU-6, CM-6, AC-3 on a single S3 bucket."
-- `evidence/lab-2-3/plan.json`
-- `evidence/lab-2-3/state.json`
+```bash
+# The verify step left you inside the Terraform folder. Climb back to the repo root first:
+cd ../../..
 
-## Troubleshooting
+# You're now in cgep-labs/. Stage this lab's code and evidence, then push:
+git add terraform/primitives/compliant-s3 evidence/lab-2-3
+git commit -m "Lab 2.3: compliant S3 primitive + evidence"
+git push
+```
 
-- **`BucketAlreadyExists`**, S3 bucket names are globally unique. The `random_id` suffix should prevent this; if you set `bucket_suffix` manually, change it.
-- **`AccessDenied` writing to the log bucket**, the log bucket needs the `log-delivery-write` ACL, which requires `aws_s3_bucket_ownership_controls` set to `BucketOwnerPreferred` *first*. The `depends_on` in the snippet above sequences this correctly.
-- **`failed to find SSO session section`**, Terraform's AWS provider doesn't always parse SSO config the way the CLI does. Run `eval "$(aws configure export-credentials --profile <your-sandbox> --format env)"` before Terraform commands.
-- **Terraform state lock errors**, usually a leftover from an interrupted run. `terraform force-unlock <lock-id>` if you're sure no one else is applying.
-- **Region mismatch**, your AWS profile may default to one region while the provider says `us-east-1`. The provider wins for resource creation, but `aws s3api` reads fall back to the profile region. Pass `--region us-east-1` to `aws s3api` if a verification check returns "NoSuchBucket".
+## Cleanup: tear down the live resources
 
-## Cleanup
+With your evidence captured and pushed, the buckets have done their job. Destroy them now so they don't linger in your account. This only removes the live AWS resources; your committed evidence files stay in the repo as proof they once existed exactly as configured.
 
-Versioned buckets can't be destroyed while they hold any object versions. Empty them first:
+**First, get back into the Terraform workspace.** The commit step above left you at the repo root, but `terraform destroy` only works where the state lives. Move into the lab folder before running anything below:
+
+```bash
+# from the repo root (cgep-labs)
+cd terraform/primitives/compliant-s3
+```
+
+Versioned buckets won't delete while they still hold object versions, so empty them first, then destroy:
 
 ```bash
 LOG_BUCKET=$(terraform output -raw log_bucket_arn | sed 's/.*:::\(.*\)/\1/')
 
-# Empty the primary bucket (rare for it to have anything yet, but be safe)
-aws s3 rm "s3://$(terraform output -raw bucket_name)" --recursive --profile <your-sandbox>
+# Empty the primary bucket (probably nothing in it yet, but be safe)
+aws s3 rm "s3://$(terraform output -raw bucket_name)" --recursive --profile default
 
-# The log bucket may have access-log objects. Empty all versions:
-aws s3api list-object-versions --profile <your-sandbox> --bucket "$LOG_BUCKET" \
+# The log bucket may hold access-log objects. Empty all versions:
+aws s3api list-object-versions --profile default --bucket "$LOG_BUCKET" \
   --query '{Objects: Versions[].{Key:Key,VersionId:VersionId}}' --output json \
-  | aws s3api delete-objects --profile <your-sandbox> --bucket "$LOG_BUCKET" --delete file:///dev/stdin || true
+  | aws s3api delete-objects --profile default --bucket "$LOG_BUCKET" --delete file:///dev/stdin || true
 
 terraform destroy -auto-approve
 ```
 
-If you destroyed within a few minutes of applying, the log bucket is probably empty and the `delete-objects` call no-ops harmlessly.
+> **Heads up: `destroy` will ask you for those two values again.** It re-reads your `.tf` files to work out what to tear down, so just like `plan` it prompts for `project_name` and `environment` (no saved plan to reuse this time). Enter the same values you used to build — `cgep-lab` and `dev` — reading each prompt label rather than going by order.
 
-## How this feeds the capstone
+If you'd rather not be prompted, pass them as flags instead:
 
-This is your first compliant primitive. By the end of the course you'll have a dozen.
+```bash
+terraform destroy -auto-approve -var="project_name=cgep-lab" -var="environment=dev"
+```
 
-- **Ch 3**, you'll write Rego policies that read this exact `plan.json` and prove each control is in place. The `state.json` becomes a continuous-evaluation input.
-- **Ch 4**, the `terraform plan + show -json` ritual you ran by hand becomes a CI step. The `evidence/lab-2-3/` artifacts are the seed of the signed evidence bundles your pipeline will produce.
-- **Ch 6**, you'll write an OSCAL Component Definition for this module. SC-28's `implemented-requirement` will point at the `evidence/lab-2-3/state.json` URI. An assessor reads the OSCAL, follows the link, sees the same JSON you just generated. The audit becomes a traversal.
+If you destroy within a few minutes of applying, the log bucket is probably still empty and the `delete-objects` call simply does nothing.
+
+Before you commit, open **`terraform/primitives/compliant-s3/README.md`** (scaffolded empty during repo setup) and write one paragraph: this module enforces SC-28, AU-3, AU-6, CM-6, AC-3 on a single S3 bucket.
+
+## Portfolio submission checklist
+
+Your `cgep-labs` repo on GitHub should now contain:
+
+- [ ] `terraform/primitives/compliant-s3/main.tf`
+- [ ] `terraform/primitives/compliant-s3/variables.tf`
+- [ ] `terraform/primitives/compliant-s3/outputs.tf`
+- [ ] `terraform/primitives/compliant-s3/README.md`, one paragraph: "this module enforces SC-28, AU-3, AU-6, CM-6, AC-3 on a single S3 bucket."
+- [ ] `evidence/lab-2-3/plan.json`
+- [ ] `evidence/lab-2-3/state.json`
+- [ ] No `.terraform/` directory, `.terraform.lock.hcl`, `tfplan`, or `*.tfstate` files committed (your `.gitignore` handles this; double-check with `git status`).
+- [ ] Live AWS resources destroyed once your evidence was committed (`terraform destroy` ran clean). Your committed evidence stays in the repo regardless.
+
+## Troubleshooting
+
+- **`BucketAlreadyExists`.** S3 bucket names are globally unique. The `random_id` suffix should prevent this; if you set `bucket_suffix` by hand, pick something more unique.
+- **`AccessDenied` writing to the log bucket.** The log bucket needs the `log-delivery-write` ACL, which requires `aws_s3_bucket_ownership_controls` set to `BucketOwnerPreferred` *first*. The `depends_on` in Step 4 sequences this for you, so don't remove it.
+- **`failed to find SSO session section`.** Terraform's AWS provider doesn't always parse SSO config the way the CLI does. Run `eval "$(aws configure export-credentials --profile default --format env)"` before your Terraform commands.
+- **Terraform state lock errors.** Usually a leftover from an interrupted run. Run `terraform force-unlock <lock-id>` only if you're sure no one else is applying.
+- **Region mismatch / `NoSuchBucket` on a verify command.** Your profile may default to a different region than the provider's `us-east-1`. Add `--region us-east-1` to the `aws s3api` command.
+- **(Windows) a command fails with a path that looks half-converted.** Git Bash rewrote a `/`-leading argument. Re-run with `MSYS_NO_PATHCONV=1` in front of the command.
+- **(Windows) shell scripts behaving strangely after editing.** Confirm you ran `git config --global core.autocrlf input`. Line-ending conversion is the usual culprit.
+
+## How this feeds the rest of the course
+
+This is your first compliant primitive. By the end of the course you'll have a dozen, and they'll all share the structure you just built.
+
+- **Chapter 3:** you'll write Rego policies that read this exact `plan.json` and prove each control is in place. The `state.json` becomes a continuous-evaluation input.
+- **Chapter 4:** the `terraform plan` plus `show -json` ritual you ran by hand becomes a step in a CI pipeline. The `evidence/lab-2-3/` artifacts are the seed of the signed evidence bundles your pipeline will produce.
+- **Chapter 6:** you'll write an OSCAL Component Definition for this module. SC-28's implementation will point at `evidence/lab-2-3/state.json`. An assessor reads the OSCAL, follows the link, and sees the same JSON you just generated. The audit becomes a matter of following links rather than scheduling a screen-share.
+
+That's the arc. A bucket today, a self-evidencing compliance pipeline by the end. You've built the first piece and, just as importantly, the shape that holds all the rest.

--- a/guides/02_04_terraform_modules_for_compliance.md
+++ b/guides/02_04_terraform_modules_for_compliance.md
@@ -1,73 +1,126 @@
 # Lab 2.4: Terraform Modules for Compliance (GCP)
 
-Lab 2.3 built one bucket. This lab builds a pattern. The shift to feel: you don't deploy buckets, you deploy a module that deploys buckets, and the security floor sits inside the module where consumers can't reach it.
+In Lab 2.3 you built one bucket on AWS. This lab builds a *pattern* on GCP. The shift is worth naming up front, because it's the whole point: you stop deploying buckets and start deploying a **module** that deploys buckets, with the security baseline locked inside the module where the people using it can't switch it off.
 
-## Learning objectives
+For the GRC folks, this is the moment the "policy" stops being a document and becomes a thing that enforces itself. For the technical folks, this is ordinary module composition, with the twist that the module's job is compliance rather than convenience. You'll write one module and call it twice, once for a dev environment and once for prod, and watch the same controls hold under different business settings.
 
-- Compose a Terraform module with a clear interface: inputs, outputs, hardcoded compliance defaults.
-- Encode SC-12, SC-13, SC-28, AU-11, and CM-6 controls so they cannot be turned off by a consumer.
-- Emit a compliance attestation as a module output that downstream labs consume as evidence.
+## Before you begin
 
-## Prerequisites
+If this is your first lab, work through [Set up your tools](../getting-started/tools.md) and [Set up your repo](../getting-started/repo-structure.md) first. They establish the `cgep-labs` repository and the tooling every lab uses. The rest of this guide assumes that's in place.
 
-- A GCP project you control, with billing enabled. Examples below use the placeholder `your-gcp-project`; substitute your project ID.
-- `gcloud` authenticated for both interactive (`gcloud auth login`) and Application Default Credentials (`gcloud auth application-default login`). Terraform's google provider uses ADC.
-- Roles: `roles/storage.admin`, `roles/cloudkms.admin` on the project.
-- Cloud KMS API enabled: `gcloud services enable cloudkms.googleapis.com`.
-- Terraform `>= 1.6`.
+This lab runs on **Google Cloud**, so it needs one tool you haven't used yet and a little auth setup:
 
-## Estimated time & cost
+- **Google Cloud CLI (`gcloud`)**, the GCP equivalent of the AWS CLI. Install it from the official page: https://cloud.google.com/sdk/docs/install
+- A **GCP project** you control, with billing enabled. Substitute your project ID wherever you see `your-gcp-project`.
+- The Cloud KMS API turned on: `gcloud services enable cloudkms.googleapis.com`
+- Roles `roles/storage.admin` and `roles/cloudkms.admin` on the project.
+- Terraform `>= 1.6` (you already have this from Lab 2.3).
+
+### One gcloud quirk that trips everyone up: ADC
+
+`gcloud` actually has two separate logins, and Terraform cares about the second one.
+
+```bash
+gcloud auth login                      # logs YOU in, for running gcloud commands
+gcloud auth application-default login  # logs in Application Default Credentials, which TERRAFORM uses
+```
+
+If you only run the first, your `gcloud` commands will work but Terraform will fail to authenticate, which is a confusing error the first time you hit it. Run both. The second one is what Terraform's Google provider reads.
+
+## Time and cost
 
 - Time: 45 to 60 minutes.
-- Cost: KMS keys are billed at about $0.06 per active key version per month. If you destroy the day you create, prorated cost is fractions of a cent. The bucket itself is free while empty.
+- Cost: KMS keys cost about $0.06 per active key version per month. If you destroy the same day, you pay a fraction of a cent. The bucket is free while empty.
 
-## Architecture
+## What you're building, and the controls behind it
 
-The module produces one keyring, one CMEK, one IAM binding, one bucket. Two consumers (dev, prod) call the module with different `environment` and `retention_days`, getting the same security posture under different business config.
+The module produces, in one unit, a KMS keyring, a customer-managed encryption key that rotates on a schedule, an IAM binding so the storage service can use that key, and a bucket that's hardened by default. Two consumers (dev and prod) call the module with different business settings and inherit the identical security posture.
+
+| Control | What it means in plain terms | Where the module enforces it |
+|---|---|---|
+| **SC-12** | You establish and own the encryption key, rather than letting the provider hold it. | `google_kms_key_ring` + `google_kms_crypto_key` |
+| **SC-13 / SC-28** | Data is encrypted at rest with that key (a CMEK), and the key rotates. | `encryption {}` block + `rotation_period` |
+| **AC-3** | Access is uniform and the public can't reach the bucket. | `uniform_bucket_level_access` + `public_access_prevention` |
+| **AU-11** | Records are retained for a set period. | `retention_policy` |
+| **CM-6** | Required labels are present and can't be dropped. | merged `labels` |
 
 ```
-                                consumers/dev               consumers/prod
-                                       │                            │
-                                       ▼                            ▼
-                          ┌──────────────────────────────────────────────┐
-                          │        module: compliant-gcs-bucket           │
-                          │   ┌─────────────┐  ┌──────────────────────┐  │
-                          │   │ KMS keyring │─▶│ KMS crypto key       │  │
-                          │   └─────────────┘  │ rotation 90d (SC-12) │  │
-                          │                    └──────────┬───────────┘  │
-                          │                               │ encrypter    │
-                          │                               ▼              │
-                          │                    ┌──────────────────────┐  │
-                          │                    │ google_storage_bucket│  │
-                          │                    │ uniform access (AC-3)│  │
-                          │                    │ CMEK (SC-13/SC-28)   │  │
-                          │                    │ versioning + retention (AU-11) │
-                          │                    │ public-prevention=enforced     │
-                          │                    │ required labels (CM-6)         │
-                          │                    └──────────────────────┘  │
-                          └──────────────────────────────────────────────┘
+                          consumer: dev                consumer: prod
+                                │                            │
+                                ▼                            ▼
+                  ┌──────────────────────────────────────────────┐
+                  │        module: compliant-gcs-bucket           │
+                  │   KMS keyring ─▶ crypto key (rotates, SC-12/13)│
+                  │                      │ encrypter              │
+                  │                      ▼                        │
+                  │            hardened GCS bucket                 │
+                  │   uniform access · CMEK · versioning ·        │
+                  │   retention · required labels · public block  │
+                  └──────────────────────────────────────────────┘
+```
+
+## Where these files live
+
+The module is a reusable template, so it goes under `terraform/modules/`. The consumers are things you actually deploy, so they're primitives under `terraform/primitives/`.
+
+```
+cgep-labs/
+├── terraform/
+│   ├── modules/
+│   │   └── compliant-gcs-bucket/   ← the module (the security floor)
+│   │       ├── main.tf
+│   │       ├── variables.tf
+│   │       ├── outputs.tf
+│   │       └── README.md
+│   └── primitives/
+│       ├── compliant-gcs/          ← consumer: dev (you apply this)
+│       │   └── main.tf
+│       ├── compliant-gcs-prod/     ← consumer: prod (you only plan this)
+│       │   └── main.tf
+│       └── compliant-gcs-negative/ ← the validation-failure demo (plan only)
+│           └── main.tf
+└── evidence/lab-2-4/               ← filled in when you capture evidence
+```
+
+The module and the consumers are separated so the distinction stays visible. A consumer is a few lines of business config. The module is where the controls live.
+
+### Scaffold this lab's empty files
+
+Run this once from the repo root (`cgep-labs`). It creates every path in the diagram above as an empty file so the later steps are "open and paste," not "guess where this goes."
+
+```bash
+# from the repo root
+mkdir -p \
+  terraform/modules/compliant-gcs-bucket \
+  terraform/primitives/compliant-gcs \
+  terraform/primitives/compliant-gcs-prod \
+  terraform/primitives/compliant-gcs-negative \
+  evidence/lab-2-4
+
+touch \
+  terraform/modules/compliant-gcs-bucket/main.tf \
+  terraform/modules/compliant-gcs-bucket/variables.tf \
+  terraform/modules/compliant-gcs-bucket/outputs.tf \
+  terraform/modules/compliant-gcs-bucket/README.md \
+  terraform/primitives/compliant-gcs/main.tf \
+  terraform/primitives/compliant-gcs-prod/main.tf \
+  terraform/primitives/compliant-gcs-negative/main.tf
+
+find terraform/modules/compliant-gcs-bucket terraform/primitives/compliant-gcs* evidence/lab-2-4 -type f | sort
 ```
 
 ## Step-by-step walkthrough
 
-### Concept: Why a module
+### Concept: what a module actually is
 
-A module is a directory of Terraform with a clear interface: inputs, outputs, and a body. The body decides what's hardcoded. The interface decides what consumers can change. If you've done Lab 2.3, you wrote one bucket on AWS. This time you write one module on GCP and call it twice.
+A module is just a directory of Terraform with a clear interface: inputs (`variables.tf`), outputs (`outputs.tf`), and a body (`main.tf`). The body decides what's hardcoded. The interface decides what consumers are allowed to change. The compliance trick is to hardcode the security baseline in the body and expose only business settings through the interface. A consumer can choose the environment and the retention period; it cannot choose to turn off encryption, because that choice was never offered.
 
-### Concept: Design the interface
+### Step 1: Fill in `terraform/modules/compliant-gcs-bucket/main.tf`
 
-Three rules:
-
-1. `main.tf` hardcodes anything compliance-relevant: encryption, uniform access, versioning, retention behavior, required labels.
-2. `variables.tf` exposes only what business actually changes: project, environment, retention duration, names.
-3. `outputs.tf` returns evidence: identifiers, plus a computed `compliance_attestation` map.
-
-Consumers write a few lines. The module enforces the rest.
-
-### Step 1 Build `modules/compliant-gcs-bucket/main.tf`
+Open the empty **`terraform/modules/compliant-gcs-bucket/main.tf`** from the scaffold and paste:
 
 ```hcl
-# main.tf
+# terraform/modules/compliant-gcs-bucket/main.tf
 terraform {
   required_version = ">= 1.6"
   required_providers {
@@ -143,12 +196,14 @@ resource "google_storage_bucket" "bucket" {
 }
 ```
 
-Required labels live in `locals`, then merge on top of `var.labels`. A consumer can add labels but cannot suppress the four compliance ones. That asymmetry is the point.
+The line doing the most compliance work is `effective_labels = merge(var.labels, local.required_labels)`. A consumer can pass in extra labels through `var.labels`, but the four required compliance labels are merged on *top*, so a consumer can add labels and cannot suppress the required ones. That asymmetry, add-but-not-remove, is the pattern you'll reuse every time you encode a control in a module.
 
-### Step 2 Build `variables.tf` with validation
+### Step 2: Fill in `variables.tf` with validation
+
+Open **`terraform/modules/compliant-gcs-bucket/variables.tf`**. The `validation` blocks here are compliance running at plan time. The most important one refuses to let a production bucket have a short retention, before any resource exists.
 
 ```hcl
-# variables.tf
+# terraform/modules/compliant-gcs-bucket/variables.tf
 variable "gcp_project" {
   type        = string
   description = "GCP project ID where the bucket and KMS resources will live."
@@ -215,12 +270,14 @@ variable "labels" {
 }
 ```
 
-> **Why two location vars:** GCS buckets accept multi-region names like `US` and `EU`. KMS keyrings do not. The first time I tried `var.location = "US"` for both, KMS rejected with `KMS_RESOURCE_NOT_FOUND_IN_LOCATION`. Splitting the variable keeps the lesson honest. Both default to `us-central1`.
+> **Why two location variables.** GCS buckets accept multi-region names like `US` and `EU`. KMS keyrings do not; they need a single region like `us-central1`. If you set both to `US`, KMS rejects it with `KMS_RESOURCE_NOT_FOUND_IN_LOCATION`. Splitting them into two variables, both defaulting to `us-central1`, keeps that honest.
 
-### Step 3 Build `outputs.tf` returning compliance evidence
+### Step 3: Fill in `outputs.tf` returning compliance evidence
+
+Open **`terraform/modules/compliant-gcs-bucket/outputs.tf`**. Most of these outputs are identifiers. The interesting one is `compliance_attestation`, a computed map that states, in machine-readable form, exactly which controls this module enforced.
 
 ```hcl
-# outputs.tf
+# terraform/modules/compliant-gcs-bucket/outputs.tf
 output "bucket_url" {
   value       = google_storage_bucket.bucket.url
   description = "gs:// URL of the compliant bucket."
@@ -252,12 +309,14 @@ output "compliance_attestation" {
 }
 ```
 
-`compliance_attestation` is the bridge to Lab 3 (Rego asserts on it) and Lab 6 (OSCAL evidence URI points at the JSON it ends up in).
+That `compliance_attestation` is the bridge to later labs. In Chapter 3 a Rego policy reads it and refuses to merge a plan that can't produce it. In Chapter 6 the OSCAL component for this module cites the JSON it ends up in as its evidence.
 
-### Step 4 Write consumer #1: dev environment, 30-day retention
+### Step 4: Write the dev consumer
+
+Open **`terraform/primitives/compliant-gcs/main.tf`** (scaffolded earlier). This is the whole consumer.
 
 ```hcl
-# consumers/dev/main.tf
+# terraform/primitives/compliant-gcs/main.tf
 terraform {
   required_version = ">= 1.6"
   required_providers {
@@ -282,16 +341,21 @@ module "data_bucket" {
 
 output "attestation" { value = module.data_bucket.compliance_attestation }
 output "bucket_url"  { value = module.data_bucket.bucket_url }
+output "kms_key_id"  { value = module.data_bucket.kms_key_id }
 ```
 
-Six lines of business config. Twenty-plus controls.
+The `source = "../../modules/compliant-gcs-bucket"` is a relative path: from `terraform/primitives/compliant-gcs/`, climb up to `primitives`, up to `terraform`, then into `modules`. Six lines of business config, and the module supplies twenty-plus controls behind them.
 
-### Step 5 Write consumer #2: prod environment, 365-day retention
+> **Use your own bucket suffix.** GCS bucket names are globally unique across all of Google Cloud, not just your project. If everyone in the cohort uses `dev-data-001`, the first person wins and everyone else gets `Error 409: ... already exists`. Change `bucket_name_suffix` to something unique to you, for example `dev-data-<your-initials>`. Use that same personal suffix everywhere this guide shows `dev-data-001`.
 
-Same module, swap two values:
+> **Module outputs vs consumer outputs.** This catches people out. The module defines an output called `compliance_attestation`. The consumer re-exposes it under a name *it* chooses, here `attestation`. So when you run `terraform output`, you ask for the consumer's name (`attestation`), not the module's internal name. They point at the same value; only the label differs depending on which directory you're standing in.
+
+### Step 5: Write the prod consumer (plan only)
+
+Open **`terraform/primitives/compliant-gcs-prod/main.tf`**. Paste the same provider block and outputs as the dev consumer, then use this module block — same security floor, different retention:
 
 ```hcl
-# consumers/prod/main.tf
+# terraform/primitives/compliant-gcs-prod/main.tf  (module block; also include provider + outputs from Step 4)
 module "data_bucket" {
   source = "../../modules/compliant-gcs-bucket"
 
@@ -299,24 +363,25 @@ module "data_bucket" {
   project_label      = "cgep-lab"
   environment        = "prod"
   retention_days     = 365
-  bucket_name_suffix = "prod-data-001"
+  bucket_name_suffix = "prod-data-001"   # use your personal suffix, e.g. prod-data-<your-initials>
 }
 ```
 
-(Same provider block, same outputs.)
+You'll only *plan* this one, not apply it. A 365-day retention lock is real, and you don't want a bucket you can't delete for a year sitting in a lab account.
 
-### Step 6 Apply and observe
+### Step 6: Apply dev and read the attestation
 
-Run the cycle on dev. For lab purposes, prod-plan but don't apply (a 365-day retention lock takes a year to expire):
+If your Application Default Credentials have gone stale since you set them up, refresh them first with `gcloud auth application-default login`. Then:
 
 ```bash
-cd consumers/dev
+# from the repo root
+cd terraform/primitives/compliant-gcs
 terraform init
 terraform plan -out=tfplan
 terraform apply -auto-approve tfplan
 ```
 
-You'll see, at the tail:
+At the tail of the apply you'll see the attestation:
 
 ```
 attestation = {
@@ -331,13 +396,14 @@ attestation = {
 bucket_url = "gs://cgep-lab-dev-dev-data-001"
 ```
 
-That output is the SC-12 / SC-13 / SC-28 / AC-3 / CM-6 / AU-11 attestation in machine-readable form.
+That block is the SC-12 / SC-13 / SC-28 / AC-3 / CM-6 / AU-11 attestation in machine-readable form. It came out of the system; nobody typed it by hand.
 
-### Step 7 The negative test
+### Step 7: The negative test
 
-Copy `consumers/dev` to `consumers/negative-test`. Change `environment` to `prod`, change `bucket_name_suffix` to `"should-never-exist"`, leave `retention_days` at 30, and run plan:
+This is the lesson of the lab, so don't skip it. Open **`terraform/primitives/compliant-gcs-negative/main.tf`**, paste the same provider and outputs as the dev consumer, and use this module block so prod gets a too-short retention. Then run plan from that folder:
 
 ```hcl
+# terraform/primitives/compliant-gcs-negative/main.tf  (module block; also include provider + outputs from Step 4)
 module "data_bucket" {
   source = "../../modules/compliant-gcs-bucket"
 
@@ -349,34 +415,46 @@ module "data_bucket" {
 }
 ```
 
+```bash
+cd terraform/primitives/compliant-gcs-negative
+terraform init
+terraform plan
+cd ../../..   # back to the repo root
+```
+
 ```
 Error: Invalid value for variable
 
-  on main.tf line 17:
-   ...
-   var.environment is "prod"
-   var.retention_days is 30
+  var.environment is "prod"
+  var.retention_days is 30
 
 retention_days must be >= 365 when environment == "prod".
 
 This was checked by the validation rule at variables.tf:49,3-13.
 ```
 
-This is the lesson. The compliance check happened at `terraform plan`, before any resource existed, with a message specific enough that the developer fixes it without filing a ticket.
+Sit with what just happened. The compliance check fired at `terraform plan`, before any resource existed, with a message specific enough that the developer fixes it themselves without filing a ticket or waiting for a review. That's the difference between compliance as a gate at the end and compliance built into the thing developers already run.
 
-## Verification
+## Verify it from the outside
+
+Pull the names from Terraform outputs so you don't have to copy-paste from the apply screen. From the repo root (or with `-chdir` as shown):
 
 ```bash
-gcloud storage buckets describe gs://cgep-lab-dev-dev-data-001 \
+BUCKET_URL=$(terraform -chdir=terraform/primitives/compliant-gcs output -raw bucket_url)
+KMS_KEY_ID=$(terraform -chdir=terraform/primitives/compliant-gcs output -raw kms_key_id)
+
+gcloud storage buckets describe "$BUCKET_URL" \
   --format="yaml(uniform_bucket_level_access,public_access_prevention,labels,retention_policy)"
 
-gcloud storage buckets describe gs://cgep-lab-dev-dev-data-001 \
+gcloud storage buckets describe "$BUCKET_URL" \
   --format="value(default_kms_key,versioning_enabled)"
 
-gcloud kms keys describe dev-data-001-key \
-  --keyring=dev-data-001-ring --location=us-central1 \
+# KMS_KEY_ID is a full resource name; gcloud accepts it as the key argument.
+gcloud kms keys describe "$KMS_KEY_ID" \
   --format="value(rotationPeriod,nextRotationTime)"
 ```
+
+If `gcloud kms keys describe` on your CLI build rejects the full resource name, split it into the older flags instead: `--location=us-central1 --keyring=<suffix>-ring` and the short key name `<suffix>-key`, using the same personal suffix you set in the consumer.
 
 Expected, abridged:
 
@@ -391,43 +469,68 @@ retention_policy:
   retentionPeriod: '2592000'
 uniform_bucket_level_access: true
 
-projects/.../keyRings/dev-data-001-ring/cryptoKeys/dev-data-001-key  True
+projects/.../locations/us-central1/keyRings/.../cryptoKeys/...  True
 
 7776000s   2026-07-24T...
 ```
 
-Six controls, three commands.
+Six controls, three commands. Your bucket URL will include your personal suffix rather than `dev-data-001`.
 
-## Portfolio submission checklist
+## Capture your evidence
 
-- [ ] `terraform/modules/compliant-gcs-bucket/{main.tf,variables.tf,outputs.tf,README.md}` committed.
-- [ ] `terraform/primitives/compliant-gcs/` (one consumer) committed.
-- [ ] Module `README.md` lists each control by NIST family: SC-12, SC-13, SC-28, AU-11, CM-6.
-- [ ] `evidence/lab-2-4/plan.json` (output of `terraform show -json tfplan`).
-- [ ] One consumer applied at least once; `terraform output -json compliance_attestation` saved.
-
-## Troubleshooting
-
-- **`KMS_RESOURCE_NOT_FOUND_IN_LOCATION`** when `var.location` is `US`. KMS keyrings need a single-region location (`us-central1`, `europe-west4`, etc.). Buckets accept multi-region. The two-variable split in the module above is the fix.
-- **`Permission cloudkms.cryptoKeyEncrypterDecrypter denied`** during bucket creation. The GCS service account on the project must have encrypt/decrypt rights on the key. The `google_kms_crypto_key_iam_member` in the module handles it; the `depends_on` on the bucket sequences it. If you split this resource out, keep the dependency.
-- **Bucket retention policy cannot be shortened after creation.** It can only be lengthened or removed entirely. Choose retention thoughtfully, especially for prod.
-- **`googleapi: Error 409: ... already exists`** on bucket name. Bucket names are globally unique across GCP. Change `bucket_name_suffix`.
-- **`reauth related error (invalid_rapt)`** from the google provider. Run `gcloud auth application-default login` again. ADC tokens expire and Terraform won't auto-refresh them.
-
-## Cleanup
+Capture the dev consumer's plan and attestation into the repo-root evidence folder for this lab. Use the *consumer* output name (`attestation`), not the module's internal name (`compliance_attestation`):
 
 ```bash
-cd consumers/dev
+# from the repo root
+mkdir -p evidence/lab-2-4
+terraform -chdir=terraform/primitives/compliant-gcs show -json tfplan > evidence/lab-2-4/plan.json
+terraform -chdir=terraform/primitives/compliant-gcs output -json attestation > evidence/lab-2-4/attestation.json
+```
+
+The second file is the same attestation you saw on screen, captured as the machine-readable artifact a policy will check later.
+
+Before you commit, open **`terraform/modules/compliant-gcs-bucket/README.md`** (scaffolded empty) and write one short paragraph listing the controls the module enforces: SC-12, SC-13, SC-28, AU-11, CM-6, AC-3.
+
+## Commit your work
+
+```bash
+# from the repo root
+git add terraform/modules/compliant-gcs-bucket terraform/primitives/compliant-gcs* evidence/lab-2-4
+git commit -m "Lab 2.4: compliant GCS module + consumers + evidence"
+git push
+```
+
+## Cleanup: tear down the live resources
+
+With your evidence captured and pushed, destroy the dev bucket so it doesn't linger. Your committed evidence stays in the repo.
+
+```bash
+cd terraform/primitives/compliant-gcs
 terraform destroy -auto-approve
 ```
 
-Two notes:
+Two things to know:
 
-1. The bucket's `retention_policy.is_locked` is `false` in this module. If you ever set it to `true`, you cannot destroy the bucket until the retention period expires.
-2. KMS crypto keys are not truly deleted by `terraform destroy`. They enter a 30-day soft-delete state where they can still be restored. The keyring object stays around indefinitely (it cannot be deleted; it's free). For a 30-day-clean account, this is fine.
+1. The bucket's `retention_policy.is_locked` is `false` in this module, so it destroys cleanly. If you ever set it to `true`, you cannot destroy the bucket until the retention period expires. That's exactly why you never applied the prod consumer.
+2. KMS crypto keys aren't truly deleted by `terraform destroy`; they enter a 30-day soft-delete state, and the keyring object stays around (it's free and can't be deleted). For a lab account this is fine. A clean dev pass destroys in about five seconds.
 
-A real test pass on dev with `retention_days = 30` destroys cleanly in about 5 seconds with 4 resources removed.
+## Portfolio submission checklist
 
-## How this feeds the capstone
+- [ ] `terraform/modules/compliant-gcs-bucket/{main.tf,variables.tf,outputs.tf,README.md}` committed. The `README.md` lists each control by family: SC-12, SC-13, SC-28, AU-11, CM-6.
+- [ ] `terraform/primitives/compliant-gcs/` (the dev consumer) committed.
+- [ ] `evidence/lab-2-4/plan.json` and `evidence/lab-2-4/attestation.json` committed.
+- [ ] No `.terraform/` directory or `*.tfstate` files committed (your `.gitignore` handles this).
+- [ ] Live resources destroyed once evidence was committed (`terraform destroy` ran clean).
 
-Modules are how the capstone's IaC layer scales without losing the security floor. The capstone's evidence vault, workload buckets, and any other GCS storage you stand up reuse this module so the compliance floor is enforced once. In Ch 3 you'll write Rego policies that read the `compliance_attestation` output and refuse to merge a plan that can't produce it. In Ch 6 the OSCAL component for "compliant-gcs-bucket-v1" cites this module's path as its implementation, and the attestation JSON as its evidence link.
+## Troubleshooting
+
+- **Terraform fails to authenticate to GCP.** You probably ran only `gcloud auth login`. Run `gcloud auth application-default login` too; that's the credential Terraform reads.
+- **`KMS_RESOURCE_NOT_FOUND_IN_LOCATION`.** You set `var.location` to a multi-region like `US` and it flowed into the keyring. Keyrings need a single region. The two-variable split in the module is the fix; leave `kms_location` at `us-central1`.
+- **`Permission cloudkms.cryptoKeyEncrypterDecrypter denied` during bucket creation.** The GCS service account needs encrypt/decrypt rights on the key. The `google_kms_crypto_key_iam_member` resource grants it and the bucket's `depends_on` sequences it. Don't remove either.
+- **`Error 409: ... already exists` on the bucket.** Bucket names are globally unique. Change `bucket_name_suffix` to your personal suffix.
+- **`reauth related error (invalid_rapt)`.** Your ADC token expired. Run `gcloud auth application-default login` again; Terraform won't refresh it for you.
+- **Bucket retention can't be shortened.** A retention policy can only be lengthened or removed, never shortened, after creation. Choose carefully, especially for prod.
+
+## How this feeds the rest of the course
+
+Modules are how the capstone's infrastructure scales without losing its security floor. In the capstone you'll wrap your KMS and S3 hardening as a module so dev and prod consume the same baseline, exactly the discipline you practiced here. In Chapter 3 you'll write Rego that reads the `compliance_attestation` output and blocks a plan that can't produce it. In Chapter 6 the OSCAL component for "compliant-gcs-bucket" cites this module's path as its implementation and the attestation JSON as its evidence. One module, enforced once, cited everywhere.

--- a/guides/02_05_iac_as_compliance_evidence.md
+++ b/guides/02_05_iac_as_compliance_evidence.md
@@ -1,55 +1,98 @@
 # Lab 2.5: IaC as Compliance Evidence (AWS)
 
-A reviewed, signed, immutably-stored Terraform commit is stronger evidence than a screenshot. This lab builds the vault that holds your evidence and the script that puts it there.
+You've built compliant resources. This lab is about *proving* they were compliant, in a way that holds up months later when nobody remembers the deploy. You'll build a storage vault that physically refuses to let anything be deleted, and a script that captures a Terraform workspace's evidence, hashes it, and locks it away.
 
-## Learning objectives
+If Labs 2.3 and 2.4 were about building things correctly, this one is about making the record of that correctness tamper-resistant. For the GRC folks, this is chain of custody made literal. For the technical folks, this is S3 Object Lock plus a bash script, in service of a goal you may not have had to design for before: evidence an administrator can't quietly make disappear.
 
-- Define chain of custody in terms of integrity, attribution, and reproducibility.
-- Build an S3 Object Lock vault that refuses deletion by design.
-- Capture a Terraform workspace's evidence files, hash them, bundle them, and upload to the vault with a recorded VersionId.
+## Before you begin
 
-## Prerequisites
+If this is your first lab, set up [your tools](../getting-started/tools.md) and [your repo](../getting-started/repo-structure.md) first.
 
-- Lab 2.3 completed with `evidence/plan.json` and the workspace still on disk. We use it as the workspace we capture from.
-- AWS CLI v2 with a working profile (lab uses `--profile <your-sandbox>`).
-- `sha256sum` or `shasum` on PATH.
+This lab is on AWS, so you need:
+
+- A working **AWS CLI** profile. Commands below use `--profile default`; if you named your profile something else in Lab 2.3, replace `default` with that name.
+- `sha256sum` or `shasum` on your PATH. Git Bash ships `sha256sum`; macOS ships `shasum`. The script handles either.
 - Terraform `>= 1.6`.
-- Optional but recommended: Cosign installed for the signing add-on at the end.
+- Optional, for the signing step at the end: **Cosign**, from https://docs.sigstore.dev/cosign/system_config/installation/
 
-## Estimated time & cost
+> **Windows users, read this before you start the script.** Git Bash tries to convert anything that looks like a Unix path (a leading `/`) into a Windows path. The capture script and the cleanup commands below pass things that *look* like paths but aren't, such as `file:///dev/stdin` and S3 keys. If a command fails with a mangled-looking path, re-run it with `MSYS_NO_PATHCONV=1` in front. It's the single most common Windows snag in this lab.
 
-- 45 minutes.
-- Cost: Object Lock itself is free. You pay standard S3 storage rates on the bundles you upload, which for this lab will be a few KB. Under one cent if you destroy same-day.
+## Time and cost
 
-## Architecture
+- Time: about 45 minutes.
+- Cost: Object Lock itself is free. You pay standard S3 rates on the few kilobytes you upload, well under a cent if you destroy the same day.
 
-The capture script reads from your Lab 2.3 workspace, hashes everything, tars it, and writes to a vault that does not allow deletion of objects within their retention window.
+## Why code is better evidence than a screenshot
+
+A screenshot of the AWS console says "I once saw this." A Terraform plan committed to git, reviewed in a pull request, and stored in a vault that refuses deletion says something much stronger: this is what was deployed, here's who reviewed it and when, and the artifact hasn't changed since. Auditors care about three properties, and it's worth holding them in your head for the rest of the course:
+
+- **Integrity:** the evidence hasn't been altered.
+- **Attribution:** you can tell who produced it.
+- **Reproducibility:** anyone can regenerate or re-verify it.
+
+Code-as-evidence delivers all three. A screenshot delivers none. This lab builds the machinery that gives you all three automatically.
+
+## Where these files live
 
 ```
-   Lab 2.3 workspace                capture-evidence.sh                 Object Lock vault
-   ─────────────────                ───────────────────                 ─────────────────
-   tfplan, terraform/      ──▶      collect plan.json,        ──▶      s3://VAULT/runs/RUN_ID/
-   .tf files, git log               state.json, commit.txt             bundle.tar.gz
-                                    version.txt; SHA-256                Retention: GOVERNANCE
-                                    each; tar; aws put-object           or COMPLIANCE
-                                                  │
-                                                  ▼
-                                       single-line JSON receipt
-                                       (run_id, key, version_id)
+cgep-labs/
+├── terraform/
+│   └── primitives/
+│       └── evidence-vault/     ← the Object Lock vault (you build this here)
+│           ├── main.tf
+│           ├── variables.tf
+│           └── outputs.tf
+├── scripts/
+│   └── capture-evidence.sh     ← the capture script (you write this here)
+└── evidence/
+    └── lab-2-5/
+        └── receipt.json        ← the upload receipt you record
+```
+
+The vault you build in this lab is not a throwaway. It is the same evidence vault your capstone uses, so build it carefully.
+
+### Scaffold this lab's empty files
+
+Run this once from the repo root (`cgep-labs`). It creates every path in the diagram above as an empty file so the later steps are "open and paste," not "guess where this goes."
+
+```bash
+# from the repo root
+mkdir -p terraform/primitives/evidence-vault scripts evidence/lab-2-5
+
+touch \
+  terraform/primitives/evidence-vault/main.tf \
+  terraform/primitives/evidence-vault/variables.tf \
+  terraform/primitives/evidence-vault/outputs.tf \
+  scripts/capture-evidence.sh
+
+chmod +x scripts/capture-evidence.sh
+
+find terraform/primitives/evidence-vault scripts/capture-evidence.sh evidence/lab-2-5 | sort
 ```
 
 ## Step-by-step walkthrough
 
-### Concept: Why code is evidence
+### Step 0: Stand up something to capture
 
-A screenshot of an AWS console says "I once saw this." A Terraform plan committed to git, reviewed in a pull request, applied in CI, and stored in a vault that refuses deletion says "this is what was deployed, who reviewed it, when, and the artifact is unchanged since." Three properties auditors want: integrity, attribution, reproducibility. Code-as-evidence delivers all three. Screenshots deliver none.
+This lab captures evidence *from* a live Terraform workspace. On a fresh day, the bucket you built in Lab 2.3 has been destroyed, so re-apply it now to give yourself a real workspace to capture from. You already have the code committed, so this is quick:
 
-### Step 1 Build the evidence vault
+```bash
+# from the repo root
+cd terraform/primitives/compliant-s3
+eval "$(aws configure export-credentials --profile default --format env)"  # if you use SSO
+terraform init
+terraform apply -auto-approve -var="project_name=cgep-lab" -var="environment=dev"
+cd ../../..   # back to the repo root
+```
 
-Object Lock has one critical constraint: it must be enabled at bucket creation. You cannot retrofit it. Start fresh.
+Now there's a live, compliant workspace at `terraform/primitives/compliant-s3` with state on disk, which is exactly what the capture script needs.
+
+### Step 1: Build the evidence vault
+
+Object Lock has one hard rule: it must be enabled when the bucket is created. You cannot add it to an existing bucket. So this is a fresh bucket, built to be immutable from birth. Open the empty **`terraform/primitives/evidence-vault/main.tf`** from the scaffold and paste:
 
 ```hcl
-# terraform/main.tf
+# terraform/primitives/evidence-vault/main.tf
 terraform {
   required_version = ">= 1.6"
   required_providers {
@@ -137,8 +180,10 @@ resource "aws_s3_bucket_policy" "vault" {
 }
 ```
 
+Open **`terraform/primitives/evidence-vault/variables.tf`** next:
+
 ```hcl
-# terraform/variables.tf
+# terraform/primitives/evidence-vault/variables.tf
 variable "project_name" {
   type    = string
   default = "cgep-lab"
@@ -161,19 +206,21 @@ variable "retention_days" {
 }
 ```
 
+Open **`terraform/primitives/evidence-vault/outputs.tf`**:
+
 ```hcl
-# terraform/outputs.tf
+# terraform/primitives/evidence-vault/outputs.tf
 output "vault_name" {
   value       = aws_s3_bucket.vault.id
   description = "S3 bucket name of the evidence vault. Feed this to capture-evidence.sh --vault."
 }
 ```
 
-> **GOVERNANCE vs COMPLIANCE.** GOVERNANCE retention can be bypassed by a privileged caller using `--bypass-governance-retention`. COMPLIANCE cannot be bypassed by anyone, including root, until the retention window expires. Use GOVERNANCE for lab work so you can clean up. Use COMPLIANCE for real evidence. The script and the rest of the pattern are identical either way.
+> **GOVERNANCE vs COMPLIANCE, and why it matters for a lab.** In GOVERNANCE mode, a privileged caller can bypass retention with `--bypass-governance-retention`, which means you can clean up after the lab. In COMPLIANCE mode, nobody can delete a locked object until its retention expires, not even the account root. Use GOVERNANCE for lab work so you can tear down. Use COMPLIANCE when you mean it. The script and the rest of the pattern are identical either way, which is the point: you practice the real workflow and only the mode differs.
 
-### Step 2 Write `capture-evidence.sh`
+### Step 2: Write `capture-evidence.sh`
 
-A single bash script. Reads the workspace, builds a manifest, uploads, prints a JSON receipt to stdout that downstream pipelines can pipe.
+One bash script. It reads a workspace, builds a manifest of hashes, uploads a bundle to the vault, and prints a one-line JSON receipt that a pipeline can capture later. Open the empty **`scripts/capture-evidence.sh`** from the scaffold and paste:
 
 ```bash
 #!/usr/bin/env bash
@@ -250,38 +297,50 @@ printf '{"run_id":"%s","vault":"%s","key":"%s","version_id":"%s","captured_at_ut
   "$RUN_ID" "$VAULT" "$KEY" "$VERSION_ID" "$CAPTURED_AT"
 ```
 
-`set -euo pipefail` plus the `trap` handles partial-failure cleanup. The single-line JSON receipt at the end is what your CI pipeline captures and stores.
+You don't need to understand every line, but the shape is worth knowing. It collects the plan, the state, the git commit, and the Terraform version; it computes a SHA-256 of each so any later change is detectable; it tars them into one bundle; it uploads that bundle to the vault; and it prints a single-line JSON receipt with the `version_id` that uniquely identifies what it just stored. The `set -euo pipefail` and the `trap` at the top mean a partial failure cleans up after itself rather than leaving junk behind.
 
-### Step 3 Run it against Lab 2.3's workspace
+### Step 3: Run it against your Lab 2.3 workspace
+
+Apply the vault, grab its name, then run the capture against the compliant-s3 workspace you re-applied in Step 0:
 
 ```bash
-chmod +x scripts/capture-evidence.sh
-
-eval "$(aws configure export-credentials --profile <your-sandbox> --format env)"
-cd terraform && terraform init && terraform apply -auto-approve
+# from the repo root
+cd terraform/primitives/evidence-vault
+eval "$(aws configure export-credentials --profile default --format env)"
+terraform init && terraform apply -auto-approve
 VAULT=$(terraform output -raw vault_name)
+cd ../../..   # back to the repo root
 
-cd ..  # back to lab-2-5 root
 bash scripts/capture-evidence.sh \
-  --workspace ../lab-2-3 \
+  --workspace terraform/primitives/compliant-s3 \
   --run-id    test-001 \
   --vault     "$VAULT" \
-  --profile   <your-sandbox>
+  --profile   default
 ```
 
-Receipt:
+You'll get a receipt:
 
 ```json
 {"run_id":"test-001","vault":"cgep-lab-grc-evidence-vault-XXXXXXXX","key":"runs/test-001/bundle.tar.gz","version_id":"<base64-version-id>","captured_at_utc":"<iso-utc-timestamp>"}
 ```
 
-The VersionId is the durable handle. Save it. Anything that points at this evidence in the future (your OSCAL component's evidence URI, for example) uses `s3://VAULT/KEY?versionId=...`.
+The `version_id` is the durable handle to this exact evidence. Save it. Anything that points at this evidence later, like your OSCAL component's evidence link in Chapter 6, references `s3://VAULT/KEY?versionId=...`. Write the whole receipt to your evidence folder:
 
-### Step 4 Verify in S3
+```bash
+mkdir -p evidence/lab-2-5
+# paste the receipt line into the file, or capture it directly:
+bash scripts/capture-evidence.sh \
+  --workspace terraform/primitives/compliant-s3 \
+  --run-id    test-001 \
+  --vault     "$VAULT" \
+  --profile   default > evidence/lab-2-5/receipt.json
+```
+
+### Step 4: Verify the retention took hold
 
 ```bash
 aws s3api get-object-retention \
-  --bucket "$VAULT" --key runs/test-001/bundle.tar.gz --profile <your-sandbox>
+  --bucket "$VAULT" --key runs/test-001/bundle.tar.gz --profile default
 ```
 
 Expected:
@@ -295,18 +354,23 @@ Expected:
 }
 ```
 
-The retention date is set by the bucket's default rule, applied at upload. You did not have to set it explicitly.
+You never set that retention by hand. The bucket's default rule applied it automatically at upload. That's the property you want in production: evidence is born protected, not protected as an afterthought someone might forget.
 
-### Step 5 The destructive test
+### Step 5: The destructive test
 
-This is the lesson. Try to delete the object you just uploaded.
+This is the moment the whole lab is built around, so do it deliberately. Try to delete the object you just uploaded:
 
 ```bash
+# capture the current version's ID directly from S3, instead of copy-pasting it
+VERSION_ID=$(aws s3api list-object-versions --bucket "$VAULT" \
+  --prefix runs/test-001/bundle.tar.gz \
+  --query "Versions[?IsLatest].VersionId | [0]" --output text --profile default)
+
 aws s3api delete-object \
   --bucket "$VAULT" \
   --key runs/test-001/bundle.tar.gz \
-  --version-id "<base64-version-id>" \
-  --profile <your-sandbox>
+  --version-id "$VERSION_ID" \
+  --profile default
 ```
 
 You will see:
@@ -316,80 +380,86 @@ An error occurred (AccessDenied) when calling the DeleteObject operation:
 Access Denied because object protected by object lock.
 ```
 
-That message is the proof of immutability. A pipeline that uploads here, and an auditor who reads from here, both rely on this rejection. The lesson is not that S3 has a feature called Object Lock; the lesson is that your evidence is now resistant to silent tampering by an admin who would rather the evidence not exist.
+That rejection is the proof. The lesson isn't that S3 has a feature called Object Lock; it's that your evidence is now resistant to silent tampering by an administrator who would prefer the evidence didn't exist. An auditor reading from this vault, and a pipeline writing to it, both depend on that "Access Denied." It's the technical fact underneath the words "chain of custody."
 
-### Step 6 Optional: sign the bundle with Cosign
+### Step 6 (optional): Sign the bundle with Cosign
 
-Cosign keyless signing uses Sigstore's public Fulcio CA. From a laptop you authenticate via OIDC. From CI (Lab 4.4) the GitHub OIDC token flows automatically.
+If you installed Cosign, you can add a cryptographic signature. Keyless signing uses Sigstore's public infrastructure; from a laptop you authenticate through your browser, and in CI (Lab 4.4) a GitHub token does it automatically.
 
 ```bash
 COSIGN_EXPERIMENTAL=1 cosign sign-blob \
   --yes --bundle bundle.sig.bundle \
   /tmp/bundle-test-001.tar.gz
-aws s3 cp bundle.sig.bundle "s3://$VAULT/runs/test-001/bundle.sig.bundle" --profile <your-sandbox>
+aws s3 cp bundle.sig.bundle "s3://$VAULT/runs/test-001/bundle.sig.bundle" --profile default
 ```
 
-Verification (Lab 4.4 covers this end-to-end):
+Lab 4.4 covers verification end to end. For now, signing it is enough to see the shape.
+
+## Capture and commit
+
+The vault Terraform, the script, and the receipt all belong in the repo:
 
 ```bash
-cosign verify-blob \
-  --bundle bundle.sig.bundle \
-  --certificate-identity-regexp '.*' \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  /tmp/bundle-test-001.tar.gz
+git add terraform/primitives/evidence-vault scripts/capture-evidence.sh evidence/lab-2-5
+git commit -m "Lab 2.5: evidence vault + capture script + receipt"
+git push
 ```
 
-## Verification
+## Cleanup: tear down the live resources
 
-Three explicit checks that should all pass:
+Two things are live right now: the vault, and the Lab 2.3 workspace you re-applied in Step 0. Clean up both, in order, after your evidence is committed.
+
+First, empty and destroy the vault. GOVERNANCE mode lets you bypass the lock to delete; in COMPLIANCE mode you could not, which is the whole point of COMPLIANCE.
 
 ```bash
-# Object Lock configured at the bucket level
-aws s3api get-object-lock-configuration --bucket "$VAULT" --profile <your-sandbox>
+cd terraform/primitives/evidence-vault
 
-# Retention on a specific uploaded object
-aws s3api get-object-retention --bucket "$VAULT" --key runs/test-001/bundle.tar.gz --profile <your-sandbox>
+# capture the current version's ID directly from S3, instead of copy-pasting it
+VERSION_ID=$(aws s3api list-object-versions --bucket "$VAULT" \
+  --prefix runs/test-001/bundle.tar.gz \
+  --query "Versions[?IsLatest].VersionId | [0]" --output text --profile default)
 
-# Deletion attempt fails
 aws s3api delete-object --bucket "$VAULT" --key runs/test-001/bundle.tar.gz \
-  --version-id "$VERSION_ID" --profile <your-sandbox>  # expect AccessDenied
-```
-
-## Portfolio submission checklist
-
-- [ ] `terraform/primitives/evidence-vault/` deploys the vault as shown above
-- [ ] `scripts/capture-evidence.sh` is committed and executable
-- [ ] At least one bundle uploaded with its VersionId recorded in `evidence/lab-2-5/receipt.json`
-- [ ] (Stretch) A Cosign signature file alongside the bundle in the vault
-
-## Troubleshooting
-
-- **`InvalidBucketState: Object Lock configuration cannot be enabled on existing buckets`**, Object Lock must be set at bucket creation. There is no upgrade path. Destroy and recreate.
-- **`COMPLIANCE` mode and accidentally too long a retention**, you cannot shorten or remove the retention. The objects sit until they expire. For lab work, always start with `GOVERNANCE` + 1 day. Move to `COMPLIANCE` only when you intend the data to outlive you.
-- **Clock drift**, RetainUntilDate is wall-clock UTC. If your laptop or CI runner has a wildly skewed clock, retention math will surprise you. Trust the server's date, not yours.
-- **Cosign keyless from a laptop** requires a browser to complete the OIDC flow. Inside GitHub Actions it is automatic via `permissions: id-token: write`. Lab 4.4 covers the CI side.
-
-## Cleanup
-
-GOVERNANCE mode allows bypass with `--bypass-governance-retention`. Use it to delete the test object and any delete markers, then `terraform destroy`:
-
-```bash
-aws s3api delete-object --bucket "$VAULT" --key runs/test-001/bundle.tar.gz \
-  --version-id "$VERSION_ID" --bypass-governance-retention --profile <your-sandbox>
+  --version-id "$VERSION_ID" --bypass-governance-retention --profile default
 
 # remove any delete markers
-aws s3api list-object-versions --bucket "$VAULT" --output json --profile <your-sandbox> \
-  | python3 -c 'import sys,json; d=json.load(sys.stdin); items=[*d.get("Versions",[]),*d.get("DeleteMarkers",[])]; print(json.dumps({"Objects":[{"Key":o["Key"],"VersionId":o["VersionId"]} for o in items]}))' > /tmp/del.json
-aws s3api delete-objects --bucket "$VAULT" --delete file:///tmp/del.json \
-  --bypass-governance-retention --profile <your-sandbox> || true
+aws s3api list-object-versions --bucket "$VAULT" --profile default \
+  --query "[Versions[],DeleteMarkers[]][].{Key:Key,VersionId:VersionId}" --output text \
+  | while read -r key version; do
+      aws s3api delete-object --bucket "$VAULT" --key "$key" \
+        --version-id "$version" --bypass-governance-retention --profile default
+    done
 
 terraform destroy -auto-approve
 ```
 
-In COMPLIANCE mode you cannot do this. The bucket sits, with its objects, until every retention has expired. For real production evidence, that's the point. For a lab, GOVERNANCE is correct.
+Then destroy the re-applied Lab 2.3 workspace so it isn't left running:
 
-A real test pass on this lab destroys 7 resources cleanly in under five seconds.
+```bash
+cd ../compliant-s3
+# empty the buckets first (see Lab 2.3 cleanup), then:
+terraform destroy -auto-approve
+```
 
-## How this feeds the capstone
+In COMPLIANCE mode none of this deletion would be possible; the vault would sit, with its objects, until every retention expired. For real production evidence, that's exactly what you want.
 
-This vault IS the capstone's evidence vault. Every PR that closes one of the [`cgep-app-starter`](https://github.com/GRCEngClub/cgep-app-starter) gaps runs through Lab 4.3's pipeline, which calls Lab 4.4's signing step, which uploads to this vault using this exact pattern. Your Ch 6 OSCAL component's evidence links resolve to objects here. The grader downloads from here. Build it once, well.
+## Portfolio submission checklist
+
+- [ ] `terraform/primitives/evidence-vault/` deploys the Object Lock vault.
+- [ ] `scripts/capture-evidence.sh` is committed and executable.
+- [ ] `evidence/lab-2-5/receipt.json` records at least one upload with its `version_id`.
+- [ ] (Stretch) A Cosign signature file alongside the bundle in the vault.
+- [ ] Both live workspaces (vault and re-applied compliant-s3) destroyed after evidence was committed.
+
+## Troubleshooting
+
+- **`InvalidBucketState: Object Lock configuration cannot be enabled on existing buckets`.** Object Lock must be set at creation. There's no upgrade path; destroy and recreate.
+- **Accidentally used COMPLIANCE with a long retention.** You can't shorten or remove it. The objects sit until they expire. For lab work always start with GOVERNANCE and a 1-day retention.
+- **Clock drift.** `RetainUntilDate` is wall-clock UTC. A badly skewed laptop or runner clock makes retention math surprising. Trust the server's date.
+- **(Windows) a path-looking argument gets mangled.** Git Bash rewrote a `/`-leading value. Re-run with `MSYS_NO_PATHCONV=1` in front, especially for `file:///...` arguments.
+- **`Need sha256sum or shasum`.** Neither hashing tool is on your PATH. Git Bash includes `sha256sum`; on macOS `shasum` is built in. Confirm with `command -v sha256sum`.
+- **Cosign keyless from a laptop** needs a browser to complete the login. Inside GitHub Actions it's automatic. Lab 4.4 covers the CI side.
+
+## How this feeds the rest of the course
+
+This vault is the capstone's evidence vault, not a practice version of it. Every push to `main` in your capstone runs the pipeline from Chapter 4, which signs a bundle and uploads it here using this exact pattern. Your Chapter 6 OSCAL component's evidence links resolve to objects in this vault. The grader downloads from here and verifies the signature, recomputes the hash, and checks the retention. You built it once, in a lab, and it carries all the way to the finish line.

--- a/guides/03_03_writing_compliance_policies_rego.md
+++ b/guides/03_03_writing_compliance_policies_rego.md
@@ -1,48 +1,113 @@
 # Lab 3.3: Writing Compliance Policies in Rego (GCP)
 
-You wrote Terraform that satisfies controls. Now you write the policy that proves a Terraform plan satisfies those controls before it ever applies. Three policies, three NIST 800-53 controls, one library that survives a cloud change.
+Every lab so far has been about building infrastructure correctly. This one flips around: you write the thing that *checks* infrastructure, automatically, before it's ever built. You'll write three small policies that read a Terraform plan and refuse it if it violates a control, and you'll write tests that prove each policy catches what it's supposed to.
 
-## Learning objectives
+This is the heart of Policy as Code, and it's the moment a control stops being a sentence in a document and becomes a program that runs. For the GRC folks, you're encoding the rule you've always written in prose so a machine enforces it every time. For the technical folks, this is unit testing, except the thing under test is your infrastructure's compliance posture.
 
-- Author Rego policies with structured metadata that maps each rule to a NIST control.
-- Write `_test.rego` fixtures that assert both passing and failing behavior.
-- Run the suite against a real `terraform plan -json` output and watch the right resources fire.
+A heads-up: the language you'll write in, Rego, looks unfamiliar at first. It's worth pushing through the strangeness, because the payoff is a compliance check that runs in under a second with no human in the loop. There's a short "how to read Rego" primer below before you write any.
 
-## Prerequisites
+## Before you begin
 
-- OPA installed (`opa version` reports `>= 0.60.0`).
-- Terraform `>= 1.6` and the `google` provider authenticated against a GCP project (the lab's fixture creates GCS buckets and a firewall rule). Examples below use the placeholder `your-gcp-project`; substitute your project ID.
-- Lab 2.3 or 2.4 completed (you should have seen `terraform show -json` output at least once).
+If this is your first lab, set up [your tools](../getting-started/tools.md) and [your repo](../getting-started/repo-structure.md) first.
 
-## Estimated time & cost
+New tool for this lab:
 
-- 60 to 75 minutes.
-- Cost: free for this lab. We only generate `terraform plan` output. Nothing is applied.
+- **OPA (Open Policy Agent)**, the engine that runs Rego policies. Get it from the official docs at https://www.openpolicyagent.org/docs, or grab the binary directly from https://github.com/open-policy-agent/opa/releases.
+  - macOS: `brew install opa`
+  - Linux: download `opa_linux_amd64_static`, `chmod +x` it, move it onto your PATH as `opa`.
+  - Windows (Git Bash): download `opa_windows_amd64.exe`, rename it `opa.exe`, and put it on your PATH.
+  - Confirm with `opa version` (you want `>= 0.60.0`).
+
+Also useful: a GCP project (the fixture creates plan-only GCS buckets and a firewall) and the fact that you've seen `terraform show -json` output back in Lab 2.3 or 2.4. Substitute your project ID for `your-gcp-project`.
+
+## Time and cost
+
+- Time: 60 to 75 minutes. It's a new language; give yourself room.
+- Cost: free. You only ever generate a `terraform plan`. Nothing is applied.
+
+## How to read a Rego rule (read this once)
+
+A compliance policy in Rego is a set of `deny` rules. Each one says: add a message to the `deny` set when all of these conditions are true. Here's the shape, annotated:
+
+```
+deny contains msg if {        # "add msg to the deny set when..."
+    some resource in input...  # ...there's a resource in the plan...
+    resource.type == "..."     # ...of this type...           (these lines are ANDed)
+    not has_cmek(resource)     # ...that fails this check...
+    msg := sprintf("...", [..]) # ...and here's the message to record.
+}
+```
+
+Three things to hold onto:
+
+- **Every line in the block is an AND.** The rule only fires when all conditions hold. If any line is false, this rule produces nothing.
+- **`input` is the Terraform plan**, parsed into JSON. `input.planned_values.root_module.resources` is the list of resources Terraform intends to create. You're querying that structure.
+- **An empty `deny` set means "compliant."** No messages, no violations. The whole game is writing rules that stay quiet on good infrastructure and speak up on bad.
+
+That's enough to read everything below. You'll pick up the rest by doing it.
 
 ## The three policies at a glance
 
-| Control | File | Enforces |
+| Control | File | What it requires |
 |---|---|---|
-| SC-28 | `policies/sc28_encryption.rego` | Every `google_storage_bucket` has an `encryption { default_kms_key_name }` block. |
-| AC-3  | `policies/ac3_no_public.rego`   | Buckets have `uniform_bucket_level_access=true` and `public_access_prevention="enforced"`. Firewalls don't expose ports 22 or 3389 to `0.0.0.0/0`. |
-| CM-6  | `policies/cm6_required_tags.rego` | Every taggable resource carries the four required labels: `project`, `environment`, `managed_by`, `compliance_scope`. |
+| **SC-28** | `policies/sc28_encryption.rego` | Every bucket has a customer-managed encryption key. |
+| **AC-3** | `policies/ac3_no_public.rego` | Buckets aren't public; firewalls don't open ports 22 or 3389 to the world. |
+| **CM-6** | `policies/cm6_required_tags.rego` | Every taggable resource carries the four required labels. |
 
-Every deny message includes the resource address AND the NIST control ID. The developer fixes their own violation without filing a GRC ticket.
+Every deny message names the resource *and* the NIST control. That's deliberate: a developer who sees `[SC-28] google_storage_bucket.bad_no_cmek: missing customer-managed encryption key` fixes it themselves, without a GRC ticket or a meeting.
+
+## Where these files live
+
+Policies live at the repo root in `policies/`, which is exactly where your capstone expects them. The throwaway test infrastructure goes in a primitive.
+
+```
+cgep-labs/
+├── policies/
+│   ├── sc28_encryption.rego
+│   ├── ac3_no_public.rego
+│   ├── cm6_required_tags.rego
+│   ├── README.md
+│   └── tests/
+│       ├── sc28_encryption_test.rego
+│       ├── ac3_no_public_test.rego
+│       └── cm6_required_tags_test.rego
+├── terraform/primitives/policy-fixture/   ← plan-only test bed
+│   └── main.tf
+└── evidence/lab-3-3/
+    └── opa-test-results.json              ← filled in when you capture evidence
+```
+
+### Scaffold this lab's empty files
+
+Run this once from the repo root (`cgep-labs`). It creates every path in the diagram above as an empty file so the later steps are "open and paste," not "guess where this goes."
+
+```bash
+# from the repo root
+mkdir -p policies/tests terraform/primitives/policy-fixture evidence/lab-3-3
+
+touch \
+  policies/sc28_encryption.rego \
+  policies/ac3_no_public.rego \
+  policies/cm6_required_tags.rego \
+  policies/README.md \
+  policies/tests/sc28_encryption_test.rego \
+  policies/tests/ac3_no_public_test.rego \
+  policies/tests/cm6_required_tags_test.rego \
+  terraform/primitives/policy-fixture/main.tf
+
+find policies terraform/primitives/policy-fixture evidence/lab-3-3 -type f | sort
+```
 
 ## Step-by-step walkthrough
 
-### Step 1 Project structure
+### Step 1: Build the test bed
 
-```bash
-mkdir -p policies/tests terraform fixtures
-```
+A policy needs something to check. This fixture has one compliant bucket and three broken ones, each broken in exactly one way, plus a firewall left wide open. Open **`terraform/primitives/policy-fixture/main.tf`** from the scaffold and paste:
 
-### Step 2 The test bed
-
-A small Terraform fixture with both compliant and non-compliant resources gives the policy suite something concrete to flag.
+> The original lab abbreviated the three non-compliant buckets as comments. They're written out in full here so the fixture actually plans.
 
 ```hcl
-# terraform/main.tf
+# terraform/primitives/policy-fixture/main.tf
 terraform {
   required_version = ">= 1.6"
   required_providers {
@@ -85,10 +150,39 @@ resource "google_storage_bucket" "good" {
   }
 }
 
-# Non-compliant cases (each will trip exactly one policy).
-resource "google_storage_bucket" "bad_no_cmek"   { /* same as good, no encryption block */ }
-resource "google_storage_bucket" "bad_public"    { /* uniform_bucket_level_access = false */ }
-resource "google_storage_bucket" "bad_no_labels" { /* no labels */ }
+# Non-compliant: no encryption block (trips SC-28).
+resource "google_storage_bucket" "bad_no_cmek" {
+  name                        = "${var.gcp_project}-lab33-bad-no-cmek"
+  location                    = "us-central1"
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+  labels = {
+    project = "lab33", environment = "dev"
+    managed_by = "terraform", compliance_scope = "cge-p-lab"
+  }
+}
+
+# Non-compliant: public access not locked down (trips AC-3).
+resource "google_storage_bucket" "bad_public" {
+  name                        = "${var.gcp_project}-lab33-bad-public"
+  location                    = "us-central1"
+  uniform_bucket_level_access = false
+  public_access_prevention    = "inherited"
+  encryption { default_kms_key_name = google_kms_crypto_key.key.id }
+  labels = {
+    project = "lab33", environment = "dev"
+    managed_by = "terraform", compliance_scope = "cge-p-lab"
+  }
+}
+
+# Non-compliant: no labels (trips CM-6).
+resource "google_storage_bucket" "bad_no_labels" {
+  name                        = "${var.gcp_project}-lab33-bad-no-labels"
+  location                    = "us-central1"
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+  encryption { default_kms_key_name = google_kms_crypto_key.key.id }
+}
 
 resource "google_compute_network" "demo" {
   name                    = "lab33-demo"
@@ -104,18 +198,22 @@ resource "google_compute_firewall" "open_ssh" {
 }
 ```
 
-Generate `plan.json`:
+Generate the plan JSON. This is the file your policies read. If Application Default Credentials are stale, refresh them with `gcloud auth application-default login` first:
 
 ```bash
-cd terraform
+# from the repo root
+cd terraform/primitives/policy-fixture
 terraform init
 terraform plan -out=tfplan -var=gcp_project=your-gcp-project
 terraform show -json tfplan > plan.json
+cd ../../..
 ```
 
-You don't have to apply. The policies operate on `plan.json`.
+You never apply. The policies work entirely off `plan.json`, which is why this lab is free and fast.
 
-### Step 3 SC-28: Encryption at Rest
+### Step 2: SC-28, encryption at rest
+
+Open **`policies/sc28_encryption.rego`** and paste:
 
 ```rego
 # policies/sc28_encryption.rego
@@ -162,9 +260,16 @@ empty_kms_key(enc) if enc.default_kms_key_name == ""
 empty_kms_key(enc) if enc.default_kms_key_name == null
 ```
 
-> **Why `has_cmek` checks the block, not the value.** At plan time, the KMS key resource ID is "(known after apply)" because Terraform hasn't created the key yet. The plan JSON omits unknown values entirely. We accept any non-empty `encryption` block as "configured", and only fail when the block is missing or holds an empty/null key name. This is the correct policy semantics: the developer wired CMEK, the value resolves at apply.
+That `# METADATA` block at the top is the GRC bridge in code form. It ties this rule to SC-28, names the framework and severity, and states the fix. Tools can read it, and so can an auditor. The policy isn't just a check; it's self-documenting evidence of which control it implements.
 
-### Step 4 SC-28 tests
+Two details that confuse everyone the first time:
+
+- **There are two `deny` rules that look identical.** The first checks buckets declared at the top level; the second recurses into `child_modules`, because when a bucket comes from a module (like your Lab 2.4 module), Terraform nests it under `child_modules` in the plan JSON, not in the top-level resources. Miss this and your policy silently ignores every module-wrapped resource.
+- **`has_cmek` checks that the block exists, not that the key has a value.** At plan time, the KMS key ID is often "known after apply," so the JSON omits it. Requiring a populated string would wrongly fail correct code. The rule accepts any non-empty `encryption` block and only fails when it's missing or explicitly empty. That's the right semantics: the developer wired CMEK; the value resolves when it applies.
+
+### Step 3: SC-28 tests
+
+Tests are how you trust a policy. Each one feeds in a hand-built input and asserts the rule does the right thing. Open **`policies/tests/sc28_encryption_test.rego`** and paste:
 
 ```rego
 # policies/tests/sc28_encryption_test.rego
@@ -201,11 +306,11 @@ test_noncompliant_fails if {
 opa test -v policies/
 ```
 
-Both tests pass. Move on.
+The `with input as ...` swaps in your fake plan so the rule runs against it. One test proves compliant infra stays quiet; the other proves bad infra gets flagged with the right control. A policy without both halves is a policy you can't trust.
 
-### Step 5 AC-3: No public access
+### Step 4: AC-3, no public access
 
-Two rule sets in one file: buckets and firewalls.
+Two checks in one file: buckets that aren't locked down, and firewalls that open management ports to the world. Open **`policies/ac3_no_public.rego`** and paste:
 
 ```rego
 # policies/ac3_no_public.rego
@@ -272,7 +377,11 @@ deny contains msg if {
 }
 ```
 
-### Step 6 AC-3 tests
+The firewall rule reads like a sentence once you slow down: for an ingress firewall, if any source range is public and any allowed port is a management port, deny. Each `some ... in` walks a list; the whole block fires only when a public range and a management port coexist.
+
+### Step 5: AC-3 tests
+
+Open **`policies/tests/ac3_no_public_test.rego`** and paste:
 
 ```rego
 # policies/tests/ac3_no_public_test.rego
@@ -307,9 +416,9 @@ test_open_management_port_fails if {
 }
 ```
 
-### Step 7 CM-6: Required labels
+### Step 6: CM-6, required labels
 
-This one uses set subtraction. Required labels are a set; the resource's labels are a set; the difference is what's missing.
+This one uses set subtraction. The required labels are a set, the resource's labels are a set, and whatever's left after subtracting is what's missing. Open **`policies/cm6_required_tags.rego`** and paste:
 
 ```rego
 # policies/cm6_required_tags.rego
@@ -359,7 +468,9 @@ provided_labels(resource) := set() if { not resource.values.labels }
 sort_array(s) := sorted if { sorted := sort([x | some x in s]) }
 ```
 
-CM-6 test:
+> **Why `provided_labels` returns a set, not an array.** Rego's `-` (subtraction) only works on two sets. The comprehension `{k | resource.values.labels[k]}` builds a set of the label keys precisely so `required - provided` gives you the missing ones. Swap it for an array and you'll get a type error that's baffling until you know this.
+
+Open **`policies/tests/cm6_required_tags_test.rego`** and paste:
 
 ```rego
 # policies/tests/cm6_required_tags_test.rego
@@ -384,15 +495,15 @@ test_partial_fails    if { some msg in cm6.deny with input as missing;   contain
 test_no_labels_fail   if { some msg in cm6.deny with input as no_labels; contains(msg, "CM-6") }
 ```
 
-### Step 8 Run the full library against the real plan
+### Step 7: Run the whole library against the real plan
 
 ```bash
 opa test -v policies/
 # PASS: 8/8
 
-opa eval -d policies -i terraform/plan.json data.compliance.sc28.deny --format=pretty
-opa eval -d policies -i terraform/plan.json data.compliance.ac3.deny  --format=pretty
-opa eval -d policies -i terraform/plan.json data.compliance.cm6.deny  --format=pretty
+opa eval -d policies -i terraform/primitives/policy-fixture/plan.json data.compliance.sc28.deny --format=pretty
+opa eval -d policies -i terraform/primitives/policy-fixture/plan.json data.compliance.ac3.deny  --format=pretty
+opa eval -d policies -i terraform/primitives/policy-fixture/plan.json data.compliance.cm6.deny  --format=pretty
 ```
 
 Expected:
@@ -412,38 +523,51 @@ Expected:
 ]
 ```
 
-Each non-compliant resource is flagged exactly once by the right control. The good bucket is quiet.
+Read that carefully: each broken bucket is flagged exactly once, by the right control, and the good bucket is silent. That's a policy library doing its job.
 
-### Step 9 Fix the broken Terraform, re-eval
+### Step 8: Fix the fixture, watch the denies vanish
 
-Add the missing pieces to your fixture, regenerate `plan.json`, run the same evals. Every deny set is empty.
+Add the missing pieces (an `encryption` block to `bad_no_cmek`, lock down `bad_public`, labels to `bad_no_labels`), regenerate `plan.json`, and re-run the three evals. Every deny set comes back empty. That's the full developer feedback loop, start to finish, in under a minute and with no reviewer involved. That speed is the entire argument for Policy as Code.
 
-That's the full developer feedback loop in under a minute, no human reviewer required.
+When you're done with the demo, you can leave the fixture in either state. The unit tests in `policies/tests/` already prove each policy against hand-built inputs; the fixture plan is for the live walkthrough, not for grading.
 
-## Verification
+Before you capture evidence, open **`policies/README.md`** (scaffolded empty) and list each policy file with its control ID, severity, and a one-line remediation — the same facts that appear in each `# METADATA` block.
 
-- `opa test -v policies/` reports `PASS: 8/8`.
-- Eval of each `data.compliance.<control>.deny` produces exactly the expected violations against `plan.json`.
-- After fixing the fixture, all three deny sets are empty.
+## Capture your evidence
 
-## Portfolio submission checklist
+```bash
+# from the repo root
+mkdir -p evidence/lab-3-3
+opa test --format=json policies/ > evidence/lab-3-3/opa-test-results.json
+```
 
-- [ ] `policies/` committed with three policies, each with a `# METADATA` block.
-- [ ] `policies/tests/` committed with at least one passing fixture and one failing fixture per policy.
-- [ ] `evidence/lab-3-3/opa-test-results.json` (output of `opa test --format=json policies/`).
-- [ ] A `policies/README.md` listing each policy, its control, severity, and remediation.
+## Commit your work
 
-## Troubleshooting
-
-- **`rego_parse_error: yaml: ... mapping values are not allowed`** in METADATA: the YAML parser hates unquoted colons inside a value. Wrap `description:` and `remediation:` values in double quotes.
-- **A passing fixture surprises you with a deny.** Plan JSON puts module-wrapped resources under `child_modules[]`, not `root_module.resources`. The rules above recurse; if you write your own, do the same.
-- **`encryption: [{}]` for a CMEK-using bucket.** Terraform sets `default_kms_key_name` to "(known after apply)" at plan time and omits the key from JSON. Don't require the key to be a populated string in your `has_cmek` predicate; require the block to exist and not be explicitly empty.
-- **Set subtraction `required - provided` returns the wrong type.** Both operands must be sets, not arrays. `provided_labels` returns a set comprehension `{k | resource.values.labels[k]}` exactly because of this.
+```bash
+# from the repo root
+git add policies evidence/lab-3-3 terraform/primitives/policy-fixture
+git commit -m "Lab 3.3: Rego compliance policies + tests + evidence"
+git push
+```
 
 ## Cleanup
 
-The fixture is plan-only. There's nothing deployed to destroy unless you ran `terraform apply` (which the lab does not require).
+There's nothing to tear down. The fixture is plan-only; you never applied it, so no live resources exist. (If you did run `terraform apply` out of curiosity, `terraform destroy` in the fixture folder cleans it up.)
 
-## How this feeds the capstone
+## Portfolio submission checklist
 
-Your capstone's policy suite starts here. The three rules in this lab cover the most common compliance gaps, but they are written against GCP resources. In Lab 3.4 you'll add AWS variants targeting `aws_s3_bucket` and friends, and run the combined suite through Conftest as the gate the GitHub Actions pipeline calls. Same library, every cloud, one set of control IDs in your OSCAL component.
+- [ ] `policies/` holds the three policies, each with a `# METADATA` block.
+- [ ] `policies/tests/` holds passing and failing fixtures for each policy.
+- [ ] `policies/README.md` lists each policy with its control, severity, and remediation.
+- [ ] `evidence/lab-3-3/opa-test-results.json` captures the test run.
+
+## Troubleshooting
+
+- **`rego_parse_error: yaml: mapping values are not allowed`** in a METADATA block: the YAML parser chokes on unquoted colons inside a value. Wrap the `description:` and `remediation:` values in double quotes.
+- **A bucket you expected to flag passes.** Module-wrapped resources live under `child_modules[]`, not `root_module.resources`. The rules here recurse into both; if you write your own, do the same or you'll miss every module resource.
+- **A CMEK bucket fails SC-28.** At plan time the key ID is "known after apply" and missing from the JSON. Don't require a populated key string; require the block to exist. The `has_cmek` predicate already does this.
+- **`required - provided` throws a type error.** Both sides must be sets. `provided_labels` returns a set comprehension for exactly this reason.
+
+## How this feeds the rest of the course
+
+This is the start of your capstone's policy suite. The three rules here are written against GCP, and in Lab 3.4 you'll add AWS variants and wire the whole library into Conftest as the gate your CI pipeline calls on every pull request. The control IDs in these METADATA blocks become the same IDs your OSCAL component cites in Chapter 6. One policy library, written once, enforced on every change and referenced by every audit artifact you produce from here on.

--- a/guides/03_04_integrating_pac_with_terraform.md
+++ b/guides/03_04_integrating_pac_with_terraform.md
@@ -1,73 +1,122 @@
-# Lab 3.4: Integrating PaC with Terraform via Conftest (AWS)
+# Lab 3.4: Integrating Policy as Code with Terraform via Conftest (AWS)
 
-You wrote three Rego policies in Lab 3.3 against GCP fixtures. This lab does two things. It runs those policies against an AWS Terraform plan via Conftest. And, more interestingly, it forces you to add AWS variants to your library because the original GCP-typed rules don't match AWS resource types. The library survives the cloud change because the control IDs do.
+In Lab 3.3 you wrote three Rego policies against GCP fixtures. This lab runs that library against an *AWS* plan, and in doing so teaches the most important lesson in the chapter: a control ID travels across clouds, but a Rego rule that hardcodes a GCP resource type does not. You'll watch the GCP rules pass with zero coverage on AWS infrastructure, then write AWS variants that keep the same control IDs. By the end you'll have a single script, `policy-gate.sh`, that your CI pipeline calls to block any pull request that violates a control.
 
-## Learning objectives
+For the GRC folks, this is the moment "the policy" becomes cloud-portable: SC-28 means the same thing on AWS and GCP even though the implementation differs. For the technical folks, this is wiring a policy engine into the plan workflow as a fail-closed gate, the thing that turns a manual review into an automatic one.
 
-- Wire Conftest into the Terraform plan workflow as a fail-closed gate.
-- Add AWS-resource-type variants of the SC-28 and AC-3 policies, preserving control IDs.
-- Demonstrate a blocked merge by feeding a deliberately broken plan to the gate.
+## Before you begin
 
-## Prerequisites
+If this is your first lab, set up [your tools](../getting-started/tools.md) and [your repo](../getting-started/repo-structure.md) first.
 
-- Lab 2.3 (AWS S3 compliant primitive) workspace on disk. We use its plan as the input.
-- Lab 3.3 policy library (`policies/`) carried into this lab. Three rules, three controls.
-- Conftest installed (`conftest --version`). Tested with `0.50` and newer.
+New tool for this lab:
 
-## Estimated time & cost
+- **Conftest**, a utility built on OPA that runs Rego policies against structured config (like a Terraform plan) and returns a pass/fail exit code, which is exactly what a CI gate needs. Official install: https://www.conftest.dev/install/ (releases at https://github.com/open-policy-agent/conftest/releases).
+  - macOS: `brew install conftest`
+  - Linux/Windows: download the archive from the releases page, extract `conftest`, put it on your PATH.
+  - Confirm with `conftest --version` (tested with 0.50 and newer).
 
-- 45 minutes.
-- Free. No additional AWS resources beyond Lab 2.3.
+You also need your `policies/` library from Lab 3.3 already in the repo (it is, since the wiki keeps one `policies/` directory at the root), and your Lab 2.3 AWS S3 code committed under `terraform/primitives/compliant-s3/`.
+
+> Because the repo has a single `policies/` directory, the original lab's "copy the policy folder from the previous lab" step disappears. Your 3.3 library is already where this lab needs it.
+
+## Time and cost
+
+- Time: about 45 minutes.
+- Cost: free. You only generate plans; nothing is applied.
 
 ## Architecture
 
 ```
-  Lab 2.3 workspace          policy-gate.sh (this lab)         CI (Lab 4.3)
-  ─────────────────          ────────────────────────         ──────────────
-  terraform plan -out=tfplan ─▶  terraform show -json    ─▶   on every PR:
-                                  conftest test               run policy-gate.sh,
-                                  (per namespace)             fail closed on any
-                                                              violation
+  Lab 2.3 code                  policy-gate.sh (this lab)        CI (Lab 4.3)
+  ────────────                  ────────────────────────        ────────────
+  terraform plan -out=tfplan ─▶ terraform show -json     ─▶     on every PR:
+                                conftest test                   run policy-gate.sh,
+                                (per control namespace)         fail closed on any
+                                                                violation
+```
+
+## Where these files live
+
+```
+cgep-labs/
+├── policies/
+│   ├── sc28_encryption_aws.rego      ← new in this lab
+│   ├── ac3_no_public_aws.rego        ← new in this lab
+│   ├── cm6_required_tags_aws.rego    ← new in this lab
+│   └── README.md                     ← update for AWS variants
+├── scripts/
+│   └── policy-gate.sh                ← new in this lab
+└── evidence/lab-3-4/
+    ├── conftest-pass.json            ← filled in when you run the gate
+    └── conftest-fail.json            ← filled in when you run the gate
+```
+
+### Scaffold this lab's empty files
+
+Run this once from the repo root (`cgep-labs`). It creates every path in the diagram above as an empty file so the later steps are "open and paste," not "guess where this goes."
+
+```bash
+# from the repo root
+mkdir -p policies scripts evidence/lab-3-4
+
+touch \
+  policies/sc28_encryption_aws.rego \
+  policies/ac3_no_public_aws.rego \
+  policies/cm6_required_tags_aws.rego \
+  scripts/policy-gate.sh
+
+# README may already exist from Lab 3.3; create it only if missing
+touch policies/README.md
+chmod +x scripts/policy-gate.sh
+
+find policies/*_aws.rego scripts/policy-gate.sh evidence/lab-3-4 | sort
 ```
 
 ## Step-by-step walkthrough
 
-### Step 1 Carry the Lab 3.3 library forward, run its tests
+### Step 1: Confirm the 3.3 library still passes
+
+Before extending the library, make sure it's healthy:
 
 ```bash
-cp -r ../lab-3-3/policies ./policies
-opa test -v policies/    # 8/8 PASS
+# from the repo root
+opa test -v policies/    # expect 8/8 PASS
 ```
 
-Sanity check the library still works in this workspace before extending it.
+### Step 2: Generate a plan from your Lab 2.3 code
 
-### Step 2 Generate plan.json from Lab 2.3
+You don't need the Lab 2.3 bucket to be live. `terraform plan` computes what *would* be created, so a plan works even with nothing deployed. It does need AWS credentials to check current state, but it applies nothing and costs nothing.
+
+> Commands below use `--profile default`. If you named your AWS CLI profile something else in Lab 2.3, replace `default` with that name.
 
 ```bash
-cd ../lab-2-3
-eval "$(aws configure export-credentials --profile <your-sandbox> --format env)"
+# from the repo root
+cd terraform/primitives/compliant-s3
+eval "$(aws configure export-credentials --profile default --format env)"  # if you use SSO
 terraform init
-terraform plan -out=tfplan
+# Pass the same vars Lab 2.3 used so plan doesn't prompt (CI can't type answers):
+terraform plan -out=tfplan -var="project_name=cgep-lab" -var="environment=dev"
 terraform show -json tfplan > plan.json
+cd ../../..
 ```
 
-Copy `plan.json` into the Conftest workspace, or point Conftest at it directly.
+### Step 3: The cross-cloud lesson
 
-### Step 3 The cross-cloud lesson
-
-Run the GCP policies against the AWS plan:
+Run your GCP policies against the AWS plan and watch what happens:
 
 ```bash
-conftest test --policy policies --namespace compliance.sc28 plan.json
-conftest test --policy policies --namespace compliance.ac3  plan.json
-conftest test --policy policies --namespace compliance.cm6  plan.json
+conftest test --policy policies --namespace compliance.sc28 terraform/primitives/compliant-s3/plan.json
+conftest test --policy policies --namespace compliance.ac3  terraform/primitives/compliant-s3/plan.json
+conftest test --policy policies --namespace compliance.cm6  terraform/primitives/compliant-s3/plan.json
 ```
 
-The first two pass with zero coverage. They check `google_storage_bucket` and `google_compute_firewall`. There are no GCP resources in this plan. The CM-6 rule fires (or doesn't) depending on whether your AWS resources carry the four required tags.
+The SC-28 and AC-3 rules pass, but they pass with *zero coverage*. They look for `google_storage_bucket` and `google_compute_firewall`, and there are none in an AWS plan, so they have nothing to check and nothing to complain about. That's a dangerous kind of "pass": green, but meaningless.
 
-The lesson: a control ID is portable, but a Rego rule that hardcodes `resource.type == "google_storage_bucket"` is not. Either you generalize the rule or you add per-cloud variants. Adding variants keeps each rule readable; generalizing makes one rule that handles every type. We add variants here.
+This is the lesson. The control ID `SC-28` is portable; the rule `resource.type == "google_storage_bucket"` is not. You have two choices: generalize each rule to handle every cloud's types, or write per-cloud variants. Variants keep each rule short and readable, so that's what you'll do, and you'll keep the same control IDs so the library stays organized by control rather than by cloud.
 
-### Step 4 Add the AWS variant of SC-28
+### Step 4: AWS variant of SC-28
+
+Open **`policies/sc28_encryption_aws.rego`** from the scaffold and paste:
 
 ```rego
 # policies/sc28_encryption_aws.rego
@@ -110,11 +159,11 @@ references_bucket(ref, bucket_addr) if ref == sprintf("%s.id", [bucket_addr])
 references_bucket(ref, bucket_addr) if ref == sprintf("%s.bucket", [bucket_addr])
 ```
 
-> **Why match by reference, not by value.** At plan time, the bucket name is "(known after apply)" because the random_id suffix isn't generated yet. Both `aws_s3_bucket.values.bucket` and the encryption resource's `values.bucket` are `null` in the JSON. Use `configuration.root_module.resources[].expressions.bucket.references` instead. Each reference is a string like `"aws_s3_bucket.primary.id"` that Terraform resolves at apply.
+> **Why this matches by reference instead of by value.** On AWS, encryption is a separate resource that points at the bucket, not a block inside it. And at plan time the bucket name is "known after apply" (the `random_id` suffix hasn't been generated), so the value-level fields are `null` in the JSON. The rule instead reads `configuration.root_module.resources[].expressions.bucket.references`, which holds strings like `"aws_s3_bucket.primary.id"` that Terraform resolves at apply. The policy asks "is an encryption resource wired to this bucket?" rather than "do the names match?", which is the only question answerable at plan time.
 
-### Step 5 Add the AWS variant of AC-3
+### Step 5: AWS variant of AC-3
 
-The AWS variant is more discriminating than the GCP one: it requires a public-access-block resource AND that all four flags are set true.
+This one is stricter than the GCP version: it requires the public-access-block resource to exist *and* all four of its flags to be `true`. Open **`policies/ac3_no_public_aws.rego`** and paste:
 
 ```rego
 # policies/ac3_no_public_aws.rego
@@ -171,9 +220,11 @@ pab_planned_values(addr) := values if {
 }
 ```
 
-### Step 6 Add the AWS variant of CM-6
+Notice this rule reads from *both* halves of the plan JSON. It uses `configuration` to find which public-access-block points at which bucket (the wiring, known at plan time), and `planned_values` to read the four flag values (which are real booleans you set literally, not "known after apply"). Knowing which half holds which kind of fact is most of the skill in writing Terraform-plan policies.
 
-The GCP rule used `labels`. AWS uses `tags`. With provider `default_tags` enabled, the merged tag set lives in `tags_all`.
+### Step 6: AWS variant of CM-6
+
+GCP used `labels`; AWS uses `tags`. With provider `default_tags` turned on (as in your Lab 2.3 code), the merged set lands in `tags_all`. Open **`policies/cm6_required_tags_aws.rego`** and paste:
 
 ```rego
 # policies/cm6_required_tags_aws.rego
@@ -232,12 +283,14 @@ tag_keys(resource) := set() if {
 sort_array(s) := sorted if { sorted := sort([x | some x in s]) }
 ```
 
-### Step 7 Run the gate against the compliant plan
+The three `tag_keys` definitions handle three states: tags merged by `default_tags` (`tags_all`), only locally-set tags (`tags`), or none at all. Rego picks whichever definition matches, which is how you write "fall back gracefully" without an if-else ladder.
+
+### Step 7: Run the gate against the compliant plan
 
 ```bash
 for ns in compliance.sc28_aws compliance.ac3_aws compliance.cm6_aws ; do
   echo "=== $ns ==="
-  conftest test --policy policies --namespace $ns plan.json
+  conftest test --policy policies --namespace $ns terraform/primitives/compliant-s3/plan.json
 done
 ```
 
@@ -252,37 +305,42 @@ Expected:
 1 test, 1 passed, 0 warnings, 0 failures, 0 exceptions
 ```
 
-Lab 2.3's plan now has full AWS coverage from your policy library.
+Now your Lab 2.3 plan has real AWS coverage. These passes mean something, unlike the empty GCP passes in Step 3.
 
-### Step 8 Break it and watch the gate fire
+### Step 8: Break it and watch the gate fire
 
-Copy the Lab 2.3 workspace, remove the primary bucket's encryption configuration block, regenerate the plan, run Conftest:
+Copy your Lab 2.3 code to a throwaway folder, remove the encryption resource, regenerate the plan, and run the gate. (Don't commit this folder; it exists only to prove the gate works.)
 
 ```bash
-mkdir broken && cp ../lab-2-3/*.tf broken/
-# Edit broken/main.tf: delete the aws_s3_bucket_server_side_encryption_configuration.primary resource
-( cd broken && terraform init && terraform plan -out=tfplan && terraform show -json tfplan > plan.json )
+# from the repo root
+mkdir -p /tmp/broken && cp terraform/primitives/compliant-s3/*.tf /tmp/broken/
+# Edit /tmp/broken/main.tf: delete the aws_s3_bucket_server_side_encryption_configuration.primary resource
+( cd /tmp/broken && terraform init \
+    && terraform plan -out=tfplan -var="project_name=cgep-lab" -var="environment=dev" \
+    && terraform show -json tfplan > plan.json )
 
-conftest test --policy policies --namespace compliance.sc28_aws broken/plan.json
+conftest test --policy policies --namespace compliance.sc28_aws /tmp/broken/plan.json
 ```
 
 Output:
 
 ```
-FAIL - broken/plan.json - compliance.sc28_aws - [SC-28] aws_s3_bucket.primary: aws_s3_bucket has no matching aws_s3_bucket_server_side_encryption_configuration. Remediation: add one referencing this bucket.
+FAIL - /tmp/broken/plan.json - compliance.sc28_aws - [SC-28] aws_s3_bucket.primary: aws_s3_bucket has no matching aws_s3_bucket_server_side_encryption_configuration. Remediation: add one referencing this bucket.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions
 ```
 
-The exit code is non-zero. The deny message names the resource, the control, and the fix. A developer reading the failed PR knows exactly what to do.
+The exit code is non-zero, which is what makes this a *gate*: in CI, a non-zero exit fails the build and blocks the merge. The message names the resource, the control, and the fix, so the developer who broke it can fix it without anyone explaining what SC-28 means.
 
-### Step 9 The wrapper script
+### Step 9: The wrapper script
 
-The CI workflow in Lab 4.3 calls a single script. Build it now.
+Your CI workflow in Lab 4.3 calls one script. Build it now so CI has something stable to call. Open **`scripts/policy-gate.sh`** from the scaffold and paste:
 
 ```bash
 #!/usr/bin/env bash
 # scripts/policy-gate.sh
+# Usage: policy-gate.sh --workspace <path> [--policy <dir>]
+# Requires a saved tfplan inside the workspace (from terraform plan -out=tfplan).
 set -euo pipefail
 
 POLICY_DIR="policies"
@@ -300,18 +358,27 @@ done
 [[ -z "$WORKSPACE" ]] && { echo "Usage: $0 --workspace <path>" >&2; exit 2; }
 mkdir -p "$EVIDENCE_DIR"
 
-( cd "$WORKSPACE" && terraform show -json tfplan > "$WORKSPACE/plan.json" )
+# Write plan.json next to tfplan. Use -chdir so a relative WORKSPACE path
+# doesn't get doubled after a cd (a common bash footgun).
+terraform -chdir="$WORKSPACE" show -json tfplan > "$WORKSPACE/plan.json"
 
 EXIT=0
 {
   echo "["
   FIRST=1
-  for ns in compliance.sc28_aws compliance.ac3_aws compliance.cm6_aws compliance.cm6 ; do
+  # AWS namespaces only. Including a GCP namespace here would "pass" with zero
+  # coverage on an AWS plan — the exact empty-pass lesson from Step 3.
+  for ns in compliance.sc28_aws compliance.ac3_aws compliance.cm6_aws ; do
     [[ $FIRST -eq 1 ]] && FIRST=0 || printf ","
-    OUT=$(conftest test --policy "$POLICY_DIR" --namespace "$ns" --output=json "$WORKSPACE/plan.json" || true)
-    if echo "$OUT" | python3 -c 'import sys,json; d=json.load(sys.stdin); sys.exit(0 if all(len(r.get("failures") or [])==0 for r in d) else 1)'; then : ; else EXIT=1 ; fi
-    echo "$OUT"
+    # Capture JSON even when conftest exits non-zero; use that exit code for the gate.
+    set +e
+    OUT=$(conftest test --policy "$POLICY_DIR" --namespace "$ns" --output=json "$WORKSPACE/plan.json")
+    STATUS=$?
+    set -e
+    [[ $STATUS -eq 0 ]] || EXIT=1
+    printf '%s' "$OUT"
   done
+  echo
   echo "]"
 } > "$EVIDENCE_DIR/conftest-results.json"
 
@@ -321,36 +388,62 @@ fi
 exit $EXIT
 ```
 
-Key choices:
+Three choices in there are worth understanding, because you'll see the same patterns in every CI script you write:
 
-- `|| true` on each conftest call so a failure in one namespace doesn't abort the script before the others run.
-- `--output=json` so CI gets a machine-readable artifact.
-- A python3 one-liner for the pass/fail decision because portable JSON parsing in pure bash is masochism.
+- Capturing `STATUS` after each `conftest` call stops one namespace's failure from killing the script before the others run, so you collect *all* violations, not just the first.
+- `--output=json` makes the result a machine-readable artifact CI can store as evidence.
+- Pass/fail uses Conftest's own exit code. No extra JSON parser (Python, `jq`, etc.) is required — Conftest already exits non-zero when a namespace has failures.
+
+Run it both ways to produce your evidence:
+
+```bash
+# from the repo root
+mkdir -p evidence/lab-3-4
+
+# compliant: point at the Lab 2.3 workspace (needs tfplan from Step 2)
+bash scripts/policy-gate.sh --workspace terraform/primitives/compliant-s3
+cp evidence/lab-3-4/conftest-results.json evidence/lab-3-4/conftest-pass.json
+
+# failing: point at the broken copy from Step 8 (it already has its own tfplan)
+bash scripts/policy-gate.sh --workspace /tmp/broken
+cp evidence/lab-3-4/conftest-results.json evidence/lab-3-4/conftest-fail.json
+```
 
 ## Verification
 
-- Compliant plan: exit 0, zero failures across all four namespaces.
-- Broken plan: exit 1, at least one failure citing SC-28 with full metadata in the deny message.
-- `evidence/lab-3-4/conftest-results.json` exists in both runs.
+- Compliant plan: exit 0, zero failures across all namespaces.
+- Broken plan: exit 1, at least one SC-28 failure with the full remediation message.
+- `evidence/lab-3-4/conftest-results.json` exists after each run.
+
+Before you commit, update **`policies/README.md`** so it notes which file targets which cloud (the three GCP files from Lab 3.3 and the three `*_aws.rego` files from this lab).
+
+## Commit your work
+
+```bash
+# from the repo root
+git add policies/*_aws.rego policies/README.md scripts/policy-gate.sh evidence/lab-3-4
+git commit -m "Lab 3.4: AWS policy variants + Conftest gate + evidence"
+git push
+```
+
+## Cleanup
+
+Nothing to tear down in the cloud; this lab is all local evaluation. Delete the throwaway `/tmp/broken` folder when you're done. (If you generated a plan against live Lab 2.3 resources, none were applied, so there's nothing to destroy.)
 
 ## Portfolio submission checklist
 
-- [ ] `policies/` has both GCP and AWS variants for SC-28, AC-3, CM-6. Six files, three control IDs.
+- [ ] `policies/` holds GCP and AWS variants for SC-28, AC-3, CM-6 (six files, three control IDs).
 - [ ] `scripts/policy-gate.sh` committed and executable.
-- [ ] `evidence/lab-3-4/conftest-pass.json` and `evidence/lab-3-4/conftest-fail.json` captured.
+- [ ] `evidence/lab-3-4/conftest-pass.json` and `conftest-fail.json` captured.
 - [ ] `policies/README.md` notes which file targets which cloud.
 
 ## Troubleshooting
 
-- **`policies: no such file or directory`**. Conftest's `--policy` is a directory path, and it's resolved relative to your current shell. Always pass the absolute or canonically-relative path.
-- **`no policies matched`**. Your package declaration doesn't match the namespace you passed with `--namespace`. The package in the file must be the same string.
-- **A passing fixture fires anyway**. Plan JSON puts module-wrapped resources under `child_modules[]`. Recurse the same way the GCP rules do, or your library has gaps.
-- **Bucket name comparisons return undefined.** At plan time AWS resource IDs are unknown. Match by reference in `configuration.root_module.resources[].expressions.<arg>.references`, not by literal value in `planned_values`.
+- **`no policies matched`.** The `package` declared in your file doesn't match the `--namespace` string. They must be identical, character for character.
+- **`policies: no such file or directory`.** `--policy` is a directory path resolved from your current shell. Run from the repo root, or pass the full path.
+- **A bucket you expect to flag passes.** Module-wrapped resources sit under `child_modules[]`. Recurse the same way the GCP rules do, or the AWS rules will miss module output.
+- **Comparisons against bucket names come back undefined.** At plan time AWS IDs are unknown. Match by reference in `configuration...expressions.<arg>.references`, never by literal value.
 
-## Cleanup
+## How this feeds the rest of the course
 
-The Conftest gate is local. Nothing in the cloud to destroy beyond Lab 2.3.
-
-## How this feeds the capstone
-
-`scripts/policy-gate.sh` is the exact script CI calls in Lab 4.3. The capstone's GitHub Actions workflow shells out to this script with `--workspace ./terraform`, the plan is checked, the workflow goes green or red. Make this bulletproof here so you don't fight it later.
+`scripts/policy-gate.sh` is the exact script your CI calls in Lab 4.3. The capstone's GitHub Actions workflow runs it with `--workspace ./terraform`, and the build goes green or red on the result. Getting it solid here means it's one less thing to debug when the whole pipeline is running. Your six policies, three control IDs, become the same IDs your OSCAL component cites in Chapter 6, with the Conftest results as their evidence.

--- a/guides/04_03_grc_evidence_pipeline.md
+++ b/guides/04_03_grc_evidence_pipeline.md
@@ -1,48 +1,88 @@
 # Lab 4.3: Building a GRC Evidence Pipeline (AWS + GitHub Actions)
 
-The local Conftest gate from Lab 3.4 catches violations on your laptop. CI catches them across the whole team. This lab wires the gate into GitHub Actions, runs it on every pull request, and uploads a named evidence artifact for every run. The YAML file you commit IS your CM-3 + CM-6 + CA-2 + RA-5 + AU-9 evidence.
+The Conftest gate from Lab 3.4 catches violations on your laptop. That's good for you, but it does nothing for a teammate who skips it. This lab moves the gate to where nobody can skip it: GitHub's servers, running automatically on every pull request. The workflow you write plans your Terraform, runs your policies, scans for misconfigurations, and saves a named evidence file for every single run. The result is a control that enforces itself and documents itself at the same time.
 
-## Learning objectives
+This is the first lab where the "engineering" in GRC Engineering really shows. For the GRC folks, you're building continuous monitoring that produces an audit trail without anyone collecting it by hand. For the technical folks, this is a CI pipeline, with the unusual goal that its *output* is compliance evidence, not just a green check.
 
-- Wire AWS OIDC trust to a GitHub Actions workflow so the workflow assumes an IAM role without long-lived keys.
-- Run terraform plan, Conftest, and tfsec on every PR; fail closed on any high-severity finding.
-- Upload a named evidence artifact (`grc-evidence-<run-id>`) attached to every run.
+A note for anyone new to CI: continuous integration just means automation that runs on a server whenever you push code. GitHub Actions is GitHub's version. You describe the steps in a YAML file, commit it, and GitHub runs those steps for you on every pull request. That's the whole idea.
 
-## Prerequisites
+## Before you begin
 
-- A GitHub repository you own. The reference implementation is wired to the [`cgep-app-starter`](https://github.com/GRCEngClub/cgep-app-starter).
-- AWS account with permission to create an IAM OIDC provider and an IAM role.
-- Lab 2.3, Lab 3.3, Lab 3.4 artifacts (Terraform, policies, `policy-gate.sh`) committed into the repo.
-- AWS CLI v2 with a working profile.
+If this is your first lab, set up [your tools](../getting-started/tools.md) and [your repo](../getting-started/repo-structure.md) first. This lab builds on Labs 2.3, 3.3, and 3.4, so those need to be committed.
 
-## Estimated time & cost
+New tool for this lab:
 
-- 60 to 90 minutes.
-- Cost: free. GitHub Actions free tier covers this. AWS cost is the same as Lab 2.3 since this workflow only plans.
+- **GitHub CLI (`gh`)**, for creating pull requests and setting repo variables from the terminal. Install from the official page: https://cli.github.com/. Authenticate once with `gh auth login`.
+
+Two tools run *inside* the workflow on GitHub's servers, so you don't install them locally; the workflow downloads them:
+
+- **Conftest** (you already know it from Lab 3.4).
+- **tfsec**, a static scanner that flags risky Terraform. Note that tfsec is now in maintenance mode, folded into **Trivy** (`trivy config` is the supported successor, and the old check IDs carry over). The lab uses tfsec because it's small and pinnable; everything here works the same if you later switch the scan step to Trivy.
+
+You also need an AWS account where you can create an IAM role and an OIDC provider. Commands below use `--profile default`; if you named your profile something else in Lab 2.3, replace `default` with that name.
+
+## Time and cost
+
+- Time: 60 to 90 minutes. Budget extra for the OIDC setup; it's the fiddly part.
+- Cost: free. GitHub Actions' free tier covers this, and the workflow only plans, so AWS costs nothing.
 
 ## Architecture
 
 ```
-  PR opened  ───▶  workflow run
+  PR opened  ───▶  workflow runs on GitHub's servers
                        │
-                       ├── Configure AWS creds (OIDC, no keys on disk)
+                       ├── Get AWS credentials via OIDC   (no keys stored anywhere)
                        ├── terraform init / plan
-                       ├── Conftest gate          (fails closed on policy failures)
-                       ├── tfsec scan             (fails closed on high/critical)
-                       ├── Upload evidence artifact (plan.json, conftest-results.json, tfsec.sarif)
-                       └── Comment on PR with summary
+                       ├── Conftest gate                  (fails the build on a policy violation)
+                       ├── tfsec scan                     (fails on high/critical findings)
+                       ├── Upload evidence artifact        (plan.json, conftest-results.json, tfsec.sarif)
+                       └── (Lab 4.4 adds: sign + store in the vault)
 ```
 
-Lab 4.4 adds Cosign signing and uploads the bundle to the Lab 2.5 vault.
+## The OIDC idea, in plain language
+
+The workflow needs to read your AWS account to run a plan. The old way was to paste an AWS access key into GitHub's secrets. That's a long-lived credential sitting in a settings page, and if it leaks, someone has standing access to your account.
+
+OIDC replaces that with something better. GitHub and AWS establish a trust relationship once. Then, on each run, GitHub hands AWS a short-lived token that proves "this is a workflow from *this specific repository*," and AWS gives back temporary credentials that expire when the job ends. No secret is stored, nothing outlives the run, and the trust is scoped to one repo. You set this up once and forget it.
+
+## Where these files live
+
+```
+cgep-labs/
+├── terraform/primitives/oidc-trust/
+│   └── main.tf                         ← OIDC provider + IAM role
+├── .github/workflows/
+│   └── grc-gate.yml                    ← the CI pipeline
+└── evidence/lab-4-3/                   ← filled by the workflow artifact
+    ├── plan.json
+    ├── plan.txt
+    ├── conftest-results.json
+    └── tfsec.sarif
+```
+
+### Scaffold this lab's empty files
+
+Run this once from the repo root (`cgep-labs`). It creates every path in the diagram above as an empty file so the later steps are "open and paste," not "guess where this goes."
+
+```bash
+# from the repo root
+mkdir -p terraform/primitives/oidc-trust .github/workflows evidence/lab-4-3
+
+touch \
+  terraform/primitives/oidc-trust/main.tf \
+  .github/workflows/grc-gate.yml
+
+find terraform/primitives/oidc-trust .github/workflows evidence/lab-4-3 -type f | sort
+```
 
 ## Step-by-step walkthrough
 
-### Step 1 Set up GitHub OIDC trust with AWS
+### Step 1: Create the OIDC trust in AWS
 
-A small Terraform module creates the OIDC provider and a read-only role scoped to your repo.
+This small Terraform creates the OIDC provider and a read-only role bound to your repository. Put it in a primitive, since you apply it once. Open **`terraform/primitives/oidc-trust/main.tf`** from the scaffold and paste:
 
 ```hcl
-# oidc/main.tf
+# terraform/primitives/oidc-trust/main.tf
 terraform {
   required_version = ">= 1.6"
   required_providers {
@@ -86,33 +126,43 @@ resource "aws_iam_role_policy_attachment" "readonly" {
 output "role_arn" { value = aws_iam_role.grc_gate.arn }
 ```
 
-Apply:
+Apply it. Substitute your GitHub org (or username) and the `cgep-labs` repo name:
 
 ```bash
-cd oidc
+# from the repo root
+cd terraform/primitives/oidc-trust
+eval "$(aws configure export-credentials --profile default --format env)"  # if you use SSO
 terraform init
-terraform apply -var=github_org=YourOrg -var=github_repo=YourRepo
+terraform apply -var=github_org=<your-github-org> -var=github_repo=cgep-labs
+ROLE_ARN=$(terraform output -raw role_arn)
+cd ../../..
 ```
 
-If the OIDC provider already exists in the account (some other automation created it), import:
+If the account already has a GitHub OIDC provider (some other automation may have created one), Terraform will error on the duplicate. Import it instead of recreating:
 
 ```bash
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --profile default)
 terraform import aws_iam_openid_connect_provider.github \
-  arn:aws:iam::ACCOUNT:oidc-provider/token.actions.githubusercontent.com
-terraform apply -var=github_org=YourOrg -var=github_repo=YourRepo
+  "arn:aws:iam::${ACCOUNT_ID}:oidc-provider/token.actions.githubusercontent.com"
+terraform apply -var=github_org=<your-github-org> -var=github_repo=cgep-labs
+ROLE_ARN=$(terraform output -raw role_arn)
 ```
 
-The `StringLike` on `sub` keeps this role bound to one specific repository. Don't loosen it. A role trusted by `repo:*:*` is trusted by every public repo on GitHub.
+> The `StringLike` condition on `sub` is what binds this role to one repository. Do not loosen it to `repo:*:*`. A role trusted by every repo on GitHub is a role trusted by every attacker who can open a public repo. This single line is the difference between scoped trust and an open door.
 
-### Step 2 Add the role ARN as a repo variable
+### Step 2: Tell GitHub which role to assume
+
+Save the role ARN as a repo variable so the workflow can read it. Use the `$ROLE_ARN` you just captured (no copy-paste from the console):
 
 ```bash
 gh variable set AWS_ROLE_ARN \
-  --body "arn:aws:iam::ACCOUNT:role/cgep-grc-gate" \
-  --repo YourOrg/YourRepo
+  --body "$ROLE_ARN" \
+  --repo <your-github-org>/cgep-labs
 ```
 
-### Step 3 Write the workflow
+### Step 3: Write the workflow
+
+This is the heart of the lab. Open **`.github/workflows/grc-gate.yml`** from the scaffold and paste. The paths here point at your `cgep-labs` layout (the compliant-s3 workspace, the root-level `policies/`, and a per-lab evidence folder).
 
 ```yaml
 # .github/workflows/grc-gate.yml
@@ -130,7 +180,7 @@ permissions:
 
 env:
   AWS_REGION: us-east-1
-  TF_WORKING_DIR: terraform
+  TF_WORKING_DIR: terraform/primitives/compliant-s3
 
 jobs:
   grc-gate:
@@ -165,147 +215,135 @@ jobs:
         run: |
           terraform init -input=false
           terraform validate
-          terraform plan -out=tfplan -no-color | tee plan.txt
+          # Same vars as Lab 2.3 / 3.4. -input=false means missing vars fail the job
+          # instead of hanging on an interactive prompt the runner can't answer.
+          terraform plan -out=tfplan -input=false -no-color \
+            -var="project_name=cgep-lab" -var="environment=dev" | tee plan.txt
           terraform show -json tfplan > plan.json
 
       - name: Conftest policy gate
         id: conftest
-        working-directory: ${{ env.TF_WORKING_DIR }}
         run: |
-          mkdir -p ../evidence
+          mkdir -p evidence/lab-4-3
+          EXIT=0
           {
             echo "["
             FIRST=1
-            for ns in compliance.sc28_aws compliance.ac3_aws compliance.cm6_aws compliance.cm6 ; do
+            # AWS namespaces only (same set as scripts/policy-gate.sh from Lab 3.4).
+            for ns in compliance.sc28_aws compliance.ac3_aws compliance.cm6_aws ; do
               [[ $FIRST -eq 1 ]] && FIRST=0 || printf ","
-              conftest test --policy ../policies --namespace "$ns" --output=json plan.json || true
+              set +e
+              OUT=$(conftest test --policy policies --namespace "$ns" --output=json "$TF_WORKING_DIR/plan.json")
+              STATUS=$?
+              set -e
+              [[ $STATUS -eq 0 ]] || EXIT=1
+              printf '%s' "$OUT"
             done
+            echo
             echo "]"
-          } > ../evidence/conftest-results.json
-          python3 -c '
-          import json, sys
-          d = json.load(open("../evidence/conftest-results.json"))
-          fails = sum(len(r.get("failures") or []) for results in d for r in results)
-          print(f"conftest failures: {fails}")
-          sys.exit(0 if fails == 0 else 1)
-          '
+          } > evidence/lab-4-3/conftest-results.json
+          if [[ $EXIT -eq 0 ]]; then echo "conftest: PASS"; else echo "conftest: FAIL"; exit 1; fi
 
       - name: tfsec scan
         id: tfsec
         if: always()
-        working-directory: ${{ env.TF_WORKING_DIR }}
         run: |
-          tfsec . --format sarif --out ../evidence/tfsec.sarif || true
-          python3 -c '
-          import json, sys
-          d = json.load(open("../evidence/tfsec.sarif"))
-          high = sum(
-              1 for run in d.get("runs", [])
-              for r in run.get("results", [])
-              if (r.get("level") or "").lower() in ("error","critical","high")
-          )
-          print(f"tfsec high+critical: {high}")
-          sys.exit(0 if high == 0 else 1)
-          '
+          # Write SARIF for the artifact, then re-run with a severity floor so
+          # tfsec's own exit code is the gate (no JSON parsing required).
+          tfsec "$TF_WORKING_DIR" --format sarif --out evidence/lab-4-3/tfsec.sarif || true
+          tfsec "$TF_WORKING_DIR" --minimum-severity HIGH
 
       - name: Copy plan into evidence
         if: always()
         run: |
-          cp ${{ env.TF_WORKING_DIR }}/plan.json evidence/plan.json
-          cp ${{ env.TF_WORKING_DIR }}/plan.txt  evidence/plan.txt
+          cp "$TF_WORKING_DIR"/plan.json evidence/lab-4-3/plan.json
+          cp "$TF_WORKING_DIR"/plan.txt  evidence/lab-4-3/plan.txt
 
       - name: Upload evidence artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: grc-evidence-${{ github.run_id }}
-          path: evidence/
+          path: evidence/lab-4-3/
           retention-days: 90
 ```
 
-A few specific choices worth understanding:
+Four choices in this file are worth understanding, because they're the difference between a workflow that works and one that fails in confusing ways:
 
-- **`permissions: id-token: write`** is required for `aws-actions/configure-aws-credentials` to mint an OIDC token. Without it, OIDC silently fails.
-- **`if: always()`** on the tfsec scan and the upload step. Without this, a Conftest failure aborts the job before evidence is captured. The whole point of CI evidence is that it's preserved on failure.
-- **`|| true`** after the conftest and tfsec calls. The tools exit non-zero on findings; we want the JSON output regardless. The pass/fail decision is made by the python3 inline checks that follow.
-- **Pinned versions** on every action. Floating tags drift. Pin them.
+- **`permissions: id-token: write`** is what lets the credentials step mint an OIDC token. Leave it out and OIDC fails silently with a misleading error. This is the single most common first-run problem.
+- **`if: always()`** on the scan, copy, and upload steps. Without it, a Conftest failure ends the job immediately and you lose the evidence. The entire value of CI evidence is that it survives the failure it documents, so these steps must run even after a gate fails.
+- **Tool-native exit codes for the gate.** Conftest exits non-zero on policy failures; `tfsec --minimum-severity HIGH` exits non-zero on high/critical findings. The SARIF/`--output=json` writes are for the evidence artifact; the tools themselves decide pass/fail. No Python (or other JSON parser) is required on the runner.
+- **Pinned versions** on every action and download (`@v4`, `v0.50.0`, `v1.28.14`). Floating tags change under you. For supply-chain safety, the more cautious choice is pinning third-party actions to a specific commit SHA rather than a moving tag.
 
-### Step 4 Open a PR and watch it run
+### Step 4: Open a PR and watch it run
 
 ```bash
+# from the repo root
 git checkout -b add-grc-gate
-git add .github/workflows/grc-gate.yml policies/ scripts/ oidc/
+git add .github/workflows/grc-gate.yml policies/ scripts/ terraform/primitives/oidc-trust/
 git commit -m "Add GRC evidence pipeline"
 git push -u origin add-grc-gate
 gh pr create --title "Add GRC evidence pipeline" --body "Reference pipeline."
 ```
 
-The workflow fires immediately. Watch:
+The workflow fires the moment the PR opens. Follow it live:
 
 ```bash
 gh run list --limit 3
 gh run watch
 ```
 
-Reference run from the [`cgep-app-starter`](https://github.com/GRCEngClub/cgep-app-starter) demo:
+If your Lab 2.3 code is compliant, the gates pass and the run goes green. If you point this at deliberately broken infrastructure (next step), you'll see output like `conftest failures: 5`. Either way, an evidence artifact named `grc-evidence-<run-id>` is attached to the run, holding `plan.json`, `conftest-results.json`, `tfsec.sarif`, and the human-readable `plan.txt`.
 
-```
-conftest failures: 5
-tfsec high+critical: 12
-```
+### Step 5: The two-PR demonstration
 
-Both gates fired. The starter has eight named gaps, so this is the expected outcome. The evidence artifact `grc-evidence-<run-id>` is attached to the run with `plan.json`, `conftest-results.json`, `tfsec.sarif`, and the human-readable `plan.txt`.
+Your capstone wants proof the gate actually blocks bad code, which means your repo history needs one PR that failed and one that passed.
 
-### Step 5 The two-PR demonstration
+1. **Red PR.** Branch off, introduce a violation (delete the `aws_s3_bucket_server_side_encryption_configuration`, or set `block_public_acls = false`), and open it as a PR. The workflow runs, Conftest fails, and with branch protection on, the merge is blocked.
+2. **Green PR.** Fix or revert the change. The workflow runs again, passes, and the PR merges.
 
-The capstone wants both a green and a red PR in your repo's history. To produce them:
+Both runs leave evidence artifacts in the Actions history. Both URLs go in your capstone write-up. That pair, a block and a pass, is the clearest possible demonstration that the control works.
 
-1. **Red PR**: open a branch that introduces a violation (delete an `aws_s3_bucket_server_side_encryption_configuration`, or pass `block_public_acls = false`). Open it as a PR. The workflow runs, Conftest fails, the merge is blocked.
-2. **Green PR**: revert or fix that change. The workflow runs again, Conftest passes, the PR merges.
+### The point: the YAML file is itself evidence
 
-Both runs leave evidence artifacts in the workflow history. Both URLs go in your capstone write-up.
+This is the idea to carry forward. Every meaningful line in this workflow maps to a control:
 
-### Takeaway: The YAML file is itself evidence
-
-Every line in `.github/workflows/grc-gate.yml` is a control statement.
-
-| Workflow content | NIST control |
+| What's in the workflow | NIST control |
 |---|---|
 | `on: pull_request` plus branch protection requiring this check | CM-3 (configuration change control) |
-| `default_tags` enforced via Conftest in this same workflow | CM-6 (configuration settings) |
-| The workflow itself is a continuous monitoring assessment | CA-2 (control assessments), CA-7 (continuous monitoring) |
-| `tfsec` scanning every change | RA-5 (vulnerability monitoring and scanning) |
-| Workflow run history retained, evidence artifacts retained 90 days, signed in Lab 4.4 | AU-9 (protection of audit information) |
+| Required tags enforced through Conftest in this same run | CM-6 (configuration settings) |
+| The workflow running on every change is itself an assessment | CA-2, CA-7 (assessment, continuous monitoring) |
+| `tfsec` scanning every change | RA-5 (vulnerability scanning) |
+| Run history and evidence retained (signed in Lab 4.4) | AU-9 (protection of audit information) |
 
-The workflow file is checked in. The history is preserved. An assessor traversing the OSCAL component you write in Lab 6.1 follows an evidence URI that points at this workflow's run output.
+The file is committed. The history is preserved. In Chapter 6, the OSCAL component you write points an evidence link straight at this workflow's run output. The auditor follows the link instead of asking you for a screenshot.
 
 ## Verification
 
-- A PR triggers the workflow.
-- The workflow run is visible in the Actions tab.
-- An evidence artifact `grc-evidence-<run-id>` is attached to the run with `plan.json`, `conftest-results.json`, `tfsec.sarif`, `plan.txt`.
-- Compliant code: workflow ends successful. Non-compliant code: workflow fails with named control IDs in the Conftest output.
+- Opening a PR triggers the workflow, visible in the Actions tab.
+- An artifact `grc-evidence-<run-id>` is attached with `plan.json`, `conftest-results.json`, `tfsec.sarif`, and `plan.txt`.
+- Compliant code ends green; non-compliant code fails with named control IDs in the Conftest output.
 
 ## Portfolio submission checklist
 
-- [ ] `oidc/` Terraform module that creates the OIDC provider + role, committed to the repo.
+- [ ] `terraform/primitives/oidc-trust/` creates the OIDC provider and role.
 - [ ] `.github/workflows/grc-gate.yml` committed.
 - [ ] `vars.AWS_ROLE_ARN` set in repo variables.
-- [ ] At least one workflow run visible in the Actions tab.
-- [ ] One green PR and one red PR in repo history (capstone requirement).
+- [ ] At least one workflow run in the Actions tab.
+- [ ] One green PR and one red PR in the repo history (capstone requirement).
 
 ## Troubleshooting
 
-- **`Error: Could not assume role with OIDC: invalid identity token`**. The `sub` condition in the trust policy doesn't match. Check the exact format: `repo:OWNER/REPO:ref:refs/heads/BRANCH` for branch pushes, `repo:OWNER/REPO:pull_request` for PR runs. Use `StringLike` with `repo:OWNER/REPO:*` for catch-all.
-- **`Permission denied`** on terraform init. The role needs read on the state backend (typically S3 + DynamoDB). `ReadOnlyAccess` covers this. For a real apply pipeline, you'd attach a more targeted policy.
-- **Conftest finds no policies**. The path passed via `--policy` is interpreted relative to the working directory of the step. Always pass an absolute or canonically-relative path.
-- **tfsec false positives**. Add a `.tfsec/config.yml` in your repo to suppress specific rule IDs with a justification comment. Don't use `--exclude` flags scattered through the workflow; centralize the exclusions.
-- **Artifact retention**. GitHub default is 90 days. For real compliance evidence, set `retention-days: 365` and copy to your Lab 2.5 vault on every successful run (Lab 4.4 wires this up).
+- **`Could not assume role with OIDC: invalid identity token`.** The `sub` condition doesn't match the run. For PR runs the subject is `repo:OWNER/REPO:pull_request`; the `StringLike` with `repo:OWNER/REPO:*` covers both PR and branch runs.
+- **`Permission denied` on terraform init.** The role needs read access to your state backend. `ReadOnlyAccess` covers a plan-only pipeline; a real apply pipeline needs a narrower, write-capable policy.
+- **Conftest finds no policies.** `--policy` is resolved from the step's working directory. The workflow above runs the gate from the repo root and passes `policies`, so don't add a `working-directory` to that step.
+- **OIDC fails even though the role exists.** Almost always the missing `id-token: write` permission. Check that block first.
+- **tfsec noise.** Suppress specific rule IDs in a `.tfsec/config.yml` with a justifying comment rather than scattering `--exclude` flags. If you migrate to Trivy, the same IDs work with a `.trivyignore` file.
 
 ## Cleanup
 
-Delete test branches. The workflow file stays; it's the deliverable. The IAM role and OIDC provider stay; they're free.
+Delete the test branches. Keep the workflow file (it's the deliverable) and the IAM role and OIDC provider (they're free and you'll reuse them). If you want them gone, `terraform destroy` in `terraform/primitives/oidc-trust/`.
 
-## How this feeds the capstone
+## How this feeds the rest of the course
 
-This is the capstone's pipeline. In Lab 4.4 we add the Cosign signing step and the upload to your Lab 2.5 vault. In Lab 6.1 your OSCAL component's evidence URIs point at signed objects in the vault, which were written by this workflow. The full chain is: PR opened, gate runs, evidence signed, evidence stored, OSCAL points at it, assessor traverses without you in the room.
+This is your capstone's pipeline. In Lab 4.4 you add a Cosign signing step and an upload to the Lab 2.5 vault, completing the chain of custody. In Chapter 6 your OSCAL component's evidence links point at signed objects this workflow produced. The full arc: a PR opens, the gate runs, evidence is captured and signed, the evidence lands in the immutable vault, and an assessor follows the OSCAL link to it, all without you in the room.

--- a/guides/04_04_evidence_chain_of_custody.md
+++ b/guides/04_04_evidence_chain_of_custody.md
@@ -1,65 +1,115 @@
-# Lab 4.4: Evidence Management & Chain of Custody (AWS)
+# Lab 4.4: Evidence Management and Chain of Custody (AWS)
 
-You have a pipeline. You have an immutable vault. This lab connects them with cryptographic signing so the evidence in the vault is provably yours, provably untampered, and provably timestamped. The auditor doesn't need to trust you. They verify.
+You have a pipeline that produces evidence (Lab 4.3) and a vault that can't be tampered with (Lab 2.5). This lab joins them with cryptographic signing, so the evidence isn't just stored, it's provably yours, provably unchanged, and provably timestamped. The shift in mindset is the whole lesson: the auditor no longer has to *trust* you. They run a command and the math tells them whether the chain is intact.
 
-## Learning objectives
+For the GRC folks, this is chain of custody turned from a paragraph in a policy into something a script verifies in seconds. For the technical folks, this is keyless signing with Sigstore wired into CI, in service of a property you may never have had to engineer before: evidence that defends itself.
 
-- Define chain of custody as four properties: authenticity, integrity, timeliness, completeness.
-- Extend the Lab 4.3 pipeline with keyless Cosign signing using GitHub OIDC.
-- Upload signed bundles to the Lab 2.5 vault and verify the full chain end-to-end with a single script.
+## Before you begin
 
-## Prerequisites
+If this is your first lab, set up [your tools](../getting-started/tools.md) and [your repo](../getting-started/repo-structure.md) first. This lab continues directly from Labs 2.5 and 4.3.
 
-- Lab 2.5 vault deployed and live. You have its bucket name handy.
-- Lab 4.3 pipeline working. Workflow runs on every PR.
-- Cosign installed locally for verification (`cosign version` reports `>= 2.0`).
+You need:
 
-## Estimated time & cost
+- **Cosign** installed locally for verification (`cosign version` reports `>= 2.0`). Official install: https://docs.sigstore.dev/cosign/system_config/installation/
+- Your Lab 4.3 workflow (`grc-gate.yml`) committed and working.
+- The Lab 2.5 vault. On a fresh day it was destroyed, so redeploy it in Step 0 below.
 
-- 60 minutes.
-- Free. Sigstore is free. Marginal S3 cost.
+> Commands below use `--profile default`. If you named your AWS CLI profile something else in Lab 2.3, replace `default` with that name.
+
+> **Hashing tools differ by OS.** macOS ships `shasum -a 256`; Git Bash and Ubuntu (including GitHub Actions runners) ship `sha256sum`. The workflow and verify script below detect whichever is available, the same way Lab 2.5's `capture-evidence.sh` does.
+
+## Time and cost
+
+- Time: about 60 minutes.
+- Cost: free. Sigstore is free; the S3 storage is fractions of a cent.
+
+## Chain of custody, in four properties
+
+Hold these four words in your head, because everything in this lab maps to one of them:
+
+- **Authenticity:** the evidence came from who it claims to (a specific repo's workflow).
+- **Integrity:** the evidence hasn't changed since it was produced.
+- **Timeliness:** there's a trustworthy record of *when* it was produced.
+- **Preservation:** it's still there, protected, when someone comes looking.
+
+Lab 2.5 gave you preservation (Object Lock). This lab adds authenticity, integrity, and timeliness through signing. Miss any one and you have a story, not a chain.
+
+## How keyless signing works (plain language)
+
+Normally signing means managing private keys, which is its own security headache. Sigstore's "keyless" approach skips that. When your workflow signs the evidence, it proves its identity using the same GitHub OIDC token from Lab 4.3. Sigstore's certificate authority (Fulcio) issues a short-lived certificate tied to that identity, and Sigstore's public transparency log (Rekor) records the signature with a timestamp. There's no private key to store or leak. The signature is bound to "this repository's workflow, at this moment," and that binding lives in Sigstore's infrastructure, not in your AWS account, so even an admin on your AWS account can't forge it.
 
 ## Architecture
 
 ```
-  PR opens
+  PR run (Lab 4.3)
+     │  produces evidence files
+     ▼
+  bundle into one tar.gz  ─▶  hash it (SHA-256)
      │
      ▼
-  workflow run  ─┬─▶  plan / policy / scan          (Lab 4.3)
-                 │
-                 ▼
-                 bundle evidence files into tar.gz
-                 │
-                 ▼
-                 cosign sign-blob --bundle (keyless via GitHub OIDC)
-                 │             │
-                 │             ▼
-                 │       Sigstore Fulcio CA issues short-lived cert
-                 │       Sigstore Rekor logs signature with timestamp
-                 ▼
-                 aws s3 cp bundle + .sha256 + .sig.bundle + receipt.json
-                                 to s3://VAULT/runs/<run_id>/
-                                 (Object Lock applies retention)
-                 │
-                 ▼
-   auditor:  scripts/verify-evidence.sh <run_id>
-             ├── recompute SHA-256 = expected         (integrity)
-             ├── cosign verify-blob --bundle          (authenticity, timestamp)
-             └── get-object-retention RetainUntilDate (preservation)
-             "CHAIN INTACT"
+  cosign sign-blob (keyless, via GitHub OIDC)
+     │   Fulcio issues a short-lived cert
+     │   Rekor logs the signature + timestamp
+     ▼
+  upload bundle + .sha256 + .sig.bundle + receipt.json
+     to s3://VAULT/runs/<run_id>/   (Object Lock applies retention)
+     │
+     ▼
+  auditor runs verify-evidence.sh <run_id>:
+     ├── recompute SHA-256 matches          → integrity
+     ├── cosign verify-blob succeeds         → authenticity + timeliness
+     └── retention not expired               → preservation
+     → "CHAIN INTACT"
+```
+
+## Where these files live
+
+```
+cgep-labs/
+├── .github/workflows/
+│   └── grc-gate.yml              ← edit: add Cosign + sign/upload + enforce-gate
+├── scripts/
+│   └── verify-evidence.sh        ← new in this lab
+└── evidence/lab-4-4/
+    └── receipt.json              ← filled in after a signed run
+```
+
+You already have `grc-gate.yml` from Lab 4.3 and the vault from Lab 2.5. This lab adds the verify script and extends the workflow.
+
+### Scaffold this lab's empty files
+
+Run this once from the repo root (`cgep-labs`). It creates the new paths; the workflow file should already exist from Lab 4.3.
+
+```bash
+# from the repo root
+mkdir -p scripts evidence/lab-4-4 .github/workflows
+
+touch scripts/verify-evidence.sh
+chmod +x scripts/verify-evidence.sh
+
+# Confirm the workflow you will edit is present
+ls -la .github/workflows/grc-gate.yml scripts/verify-evidence.sh evidence/lab-4-4
 ```
 
 ## Step-by-step walkthrough
 
-### Concept: Why signing matters
+### Step 0: Redeploy the vault
 
-Lab 2.5 made the bundle immutable. Object Lock prevents deletion, but it doesn't prove who created the bundle or when. A determined insider with admin in the AWS account can stand up a *different* bucket, drop a tampered bundle, and point a sloppy auditor at it. Cosign closes that loop. The signature ties the bundle to a specific GitHub Actions run on a specific repository at a specific moment. The certificate Sigstore issues includes the OIDC subject (`repo:GRCEngClub/cgep-app-starter:ref:refs/pull/...`). The Rekor transparency log timestamps it. None of that is bypassable by anyone with admin in your AWS account, because none of it lives in your AWS account.
+On a fresh day your Lab 2.5 vault is gone, so stand it back up and record its name:
 
-Three ways the chain breaks: mutable storage (Lab 2.5 fixed that), no signing (this lab), short retention (Lab 2.5 default-retention fixed that). Close all three or you have a story, not a chain.
+```bash
+# from the repo root
+cd terraform/primitives/evidence-vault
+eval "$(aws configure export-credentials --profile default --format env)"
+terraform init && terraform apply -auto-approve
+VAULT=$(terraform output -raw vault_name)
+cd ../../..
+gh variable set EVIDENCE_VAULT --body "$VAULT" --repo <your-github-org>/cgep-labs
+```
 
-### Step 1 Add Cosign to the workflow
+### Step 1: Add signing to the workflow
 
-Two new steps in `.github/workflows/grc-gate.yml`. After the existing scan and plan steps:
+Two additions to **`.github/workflows/grc-gate.yml`** (the file from Lab 4.3 — open that existing file, don't create a second one). First, install Cosign (add it alongside the other tool-install steps):
 
 ```yaml
 - name: Install Cosign
@@ -68,7 +118,7 @@ Two new steps in `.github/workflows/grc-gate.yml`. After the existing scan and p
     cosign-release: 'v2.2.4'
 ```
 
-Then, after `Copy plan into evidence`, the bundle/sign/upload step:
+Then, after the `Copy plan into evidence` step, add the bundle/sign/upload step:
 
 ```yaml
 - name: Bundle + sign + upload to vault
@@ -80,9 +130,13 @@ Then, after `Copy plan into evidence`, the bundle/sign/upload step:
     SHA: ${{ github.sha }}
   run: |
     set -euo pipefail
+    if command -v sha256sum >/dev/null 2>&1; then SHASUM="sha256sum"
+    elif command -v shasum >/dev/null 2>&1; then SHASUM="shasum -a 256"
+    else echo "Need sha256sum or shasum" >&2; exit 2; fi
+
     BUNDLE="evidence-${RUN_ID}-${SHA}.tar.gz"
-    ( cd evidence && tar czf "../${BUNDLE}" . )
-    shasum -a 256 "${BUNDLE}" | awk '{print $1}' > "${BUNDLE}.sha256"
+    ( cd evidence/lab-4-3 && tar czf "../../${BUNDLE}" . )
+    $SHASUM "${BUNDLE}" | awk '{print $1}' > "${BUNDLE}.sha256"
 
     cosign sign-blob --yes --bundle "${BUNDLE}.sig.bundle" "${BUNDLE}"
 
@@ -103,19 +157,44 @@ Then, after `Copy plan into evidence`, the bundle/sign/upload step:
     }
     EOF
     aws s3 cp receipt.json "s3://${VAULT}/${KEY_PREFIX}/receipt.json"
+    mkdir -p evidence/lab-4-4
+    cp receipt.json evidence/lab-4-4/receipt.json
 ```
 
-The `--bundle evidence.sig.bundle` flag packs the signature, the certificate Sigstore Fulcio issued, and the Rekor entry into one file. That file is what your verify script consumes.
+The `--bundle` flag packs the signature, Fulcio's certificate, and the Rekor log reference into one file. That single file is everything your verify script needs.
 
-> **Important**: in Lab 4.3 the policy gate exited the job on failure. Here we want to sign and store the evidence even when the gate fails, so the evidence trail is preserved. Move the pass/fail decision to the *last* step in the job. Lab 4.4's reference workflow does this.
+Also widen the existing upload-artifact step so the Lab 4.4 receipt is retained with the rest of the run evidence:
 
-### Step 2 Grant the role write to the vault
+```yaml
+- name: Upload evidence artifact
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: grc-evidence-${{ github.run_id }}
+    path: |
+      evidence/lab-4-3/
+      evidence/lab-4-4/
+    retention-days: 90
+```
 
-The Lab 4.3 OIDC role had `ReadOnlyAccess`. Grant a tight write inline policy on the vault:
+> **Sign even when the gate fails.** In Lab 4.3 the policy check could end the job before this step runs, which would mean a failed run leaves no signed evidence, exactly the runs you most want a record of. The fix is ordering: let the earlier gate steps *record* pass or fail without ending the job (they already use `if: always()` on the steps that follow), do the sign-and-upload, and put the actual build-failing decision in a final step:
+
+```yaml
+- name: Enforce gate
+  if: always()
+  run: |
+    test "${{ steps.conftest.outcome }}" = "success" \
+      && test "${{ steps.tfsec.outcome }}" = "success"
+```
+
+Now a violating PR still produces a signed, stored evidence bundle, and *then* the build goes red.
+
+### Step 2: Let the role write to the vault
+
+The Lab 4.3 role was read-only. Grant it a tight write scope on the vault and nothing else:
 
 ```bash
-eval "$(aws configure export-credentials --profile <your-sandbox> --format env)"
-VAULT=<your-vault-bucket>
+eval "$(aws configure export-credentials --profile default --format env)"
 aws iam put-role-policy \
   --role-name cgep-grc-gate \
   --policy-name vault-write \
@@ -130,12 +209,13 @@ aws iam put-role-policy \
 }
 EOF
 )"
-gh variable set EVIDENCE_VAULT --body "$VAULT" --repo OWNER/REPO
 ```
 
-Two scopes only: the vault and its objects. Nothing else.
+Two resources only: the vault and its objects. A role that can write evidence shouldn't be able to write anything else.
 
-### Step 3 The verify script
+### Step 3: The verify script
+
+This is the script an auditor runs. Three checks, three ways to fail, one line of success. Open **`scripts/verify-evidence.sh`** from the scaffold and paste:
 
 ```bash
 #!/usr/bin/env bash
@@ -149,9 +229,14 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --vault)   VAULT="$2"; shift 2 ;;
     --profile) PROFILE_ARG="--profile $2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
   esac
 done
 [[ -z "$VAULT" ]] && { echo "Set --vault or EVIDENCE_VAULT"; exit 2; }
+
+if command -v sha256sum >/dev/null 2>&1; then SHASUM="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then SHASUM="shasum -a 256"
+else echo "Need sha256sum or shasum" >&2; exit 2; fi
 
 WORK=$(mktemp -d); trap 'rm -rf "$WORK"' EXIT; cd "$WORK"
 PREFIX="runs/${RUN_ID}"
@@ -163,7 +248,7 @@ BUNDLE=$(ls evidence-*.tar.gz | head -1)
 
 # 1. Integrity
 EXPECTED=$(cat "${BUNDLE}.sha256")
-ACTUAL=$(shasum -a 256 "${BUNDLE}" | awk '{print $1}')
+ACTUAL=$($SHASUM "${BUNDLE}" | awk '{print $1}')
 [[ "$EXPECTED" == "$ACTUAL" ]] || { echo "FAIL: SHA mismatch"; exit 1; }
 
 # 2. Authenticity + timestamp
@@ -183,75 +268,90 @@ NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 echo "CHAIN INTACT for run ${RUN_ID}"
 ```
 
-Three checks, three exits if any fail. The output you want to see at the end is one line: `CHAIN INTACT`.
+Each check maps to one of the four properties: the SHA comparison is integrity, `cosign verify-blob` is authenticity and timeliness together, and the retention check is preservation. If all three pass, the script prints `CHAIN INTACT`. If any fails, it exits non-zero with the reason.
 
-### Step 4 Trigger a fresh PR
+### Step 4: Run a fresh PR and verify it
 
-Push the workflow update. The next PR run produces signed bundles. From your laptop:
+Commit the workflow changes, push, open a PR. The run produces signed bundles. Grab the run ID from the Actions tab (or `gh run list --limit 1`), then verify from your laptop without hand-copying vault paths:
 
 ```bash
-EVIDENCE_VAULT=<your-vault> bash scripts/verify-evidence.sh <run_id> --profile <your-sandbox>
+RUN_ID=$(gh run list --workflow=grc-gate.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+EVIDENCE_VAULT="$VAULT" bash scripts/verify-evidence.sh "$RUN_ID" --profile default
 ```
 
-Reference run: bundle 18.8 KB, three files (`evidence-RUN_ID-SHA.tar.gz`, `.sha256`, `.sig.bundle`) plus `receipt.json`. Verify output:
+You're looking for, at the very end:
 
 ```
-=== 1. Integrity (SHA-256) ===
-  OK (dd8a473f8c1dcd969e220296f180f8069d12564fa92ae9c488c40e2387e6adee)
-=== 2. Authenticity + timestamp (Cosign + Sigstore Rekor) ===
 Verified OK
-  OK (Cosign verified, Rekor entry exists)
-=== 3. Preservation (Object Lock retention) ===
-  OK (retain until 2026-04-27T18:30:33.696000+00:00)
-
-CHAIN INTACT for run 24963918994
+...
+CHAIN INTACT for run <run-id>
 ```
 
-### Step 5 The tamper test
+`Verified OK` is Cosign confirming the signature matches the bundle and the Rekor entry exists. `CHAIN INTACT` is your script confirming all three checks passed.
 
-Download the bundle. Modify a single byte. Re-run `verify-evidence.sh`. The integrity step fails immediately. The signature, computed over the original bytes, now disagrees with the modified file's SHA. That failure is the lesson: chain of custody is mathematical, not aspirational.
+Pull a local copy of the receipt into your repo (the workflow also writes `evidence/lab-4-4/receipt.json` into the Actions artifact, but committing it from your laptop is what lands it in GitHub):
 
 ```bash
-aws s3 cp "s3://${VAULT}/runs/${RUN_ID}/evidence-${RUN_ID}-${SHA}.tar.gz" /tmp/bundle.tar.gz --profile <your-sandbox>
-echo "junk" >> /tmp/bundle.tar.gz
-shasum -a 256 /tmp/bundle.tar.gz
-# value differs from the .sha256 sidecar; verify-evidence.sh exits 1
+mkdir -p evidence/lab-4-4
+aws s3 cp "s3://${VAULT}/runs/${RUN_ID}/receipt.json" evidence/lab-4-4/receipt.json \
+  --profile default
 ```
 
-You can't write the tampered file *back* to the vault without changing the key. Object Lock blocks overwrite of the existing key. So the only place a tampered bundle lives is your laptop. The vault stays clean. The chain stays intact.
+### Step 5: The tamper test
+
+This is the demonstration the whole lab builds toward, so do it and watch it fail. Download the bundle using the receipt (or list the prefix), change a single byte, and re-hash:
+
+```bash
+# reuse RUN_ID and VAULT from above
+BUNDLE_KEY=$(aws s3api list-objects-v2 --bucket "$VAULT" --prefix "runs/${RUN_ID}/" \
+  --query "Contents[?ends_with(Key, '.tar.gz')].Key | [0]" --output text --profile default)
+
+aws s3 cp "s3://${VAULT}/${BUNDLE_KEY}" /tmp/bundle.tar.gz --profile default
+echo "junk" >> /tmp/bundle.tar.gz
+if command -v sha256sum >/dev/null 2>&1; then sha256sum /tmp/bundle.tar.gz
+else shasum -a 256 /tmp/bundle.tar.gz; fi
+# the value now differs from the .sha256 sidecar; verification fails
+```
+
+The hash no longer matches, and the signature, computed over the original bytes, disagrees with the altered file. Verification fails instantly. That's the point of the entire chapter in one command: chain of custody here is mathematical, not a matter of anyone's good word.
+
+And notice what you *can't* do: you can't write the tampered bundle back over the original in the vault, because Object Lock refuses to overwrite the existing key. The only place a tampered copy can exist is your laptop. The vault stays clean, and the chain stays intact.
+
+## Commit your work
+
+```bash
+# from the repo root
+git add .github/workflows/grc-gate.yml scripts/verify-evidence.sh evidence/lab-4-4
+git commit -m "Lab 4.4: Cosign signing + chain-of-custody verification"
+git push
+```
 
 ## Verification
 
-- The vault contains a `bundle.tar.gz`, `bundle.tar.gz.sha256`, `bundle.tar.gz.sig.bundle`, and `receipt.json` for at least one run.
-- `verify-evidence.sh <run_id>` returns 0 with `CHAIN INTACT`.
-- Tampering the bundle and re-running returns non-zero with the specific failure (integrity).
+- The vault holds a bundle, its `.sha256`, its `.sig.bundle`, and a `receipt.json` for at least one run.
+- `verify-evidence.sh <run_id>` exits 0 with `CHAIN INTACT`.
+- Tampering with the bundle and re-running exits non-zero on the integrity check.
 
 ## Portfolio submission checklist
 
-- [ ] `.github/workflows/grc-gate.yml` updated with the Cosign install + bundle/sign/upload step.
+- [ ] `grc-gate.yml` has the Cosign install, the bundle/sign/upload step, and the final enforce-gate step.
 - [ ] `scripts/verify-evidence.sh` committed and executable.
-- [ ] At least one run's full bundle visible in the vault.
-- [ ] `WRITEUP.md` section mapping each chain property (authenticity, integrity, timeliness, preservation) to the artifact that proves it.
-
-## Troubleshooting
-
-- **`cosign sign-blob: failed to get OIDC token`** in CI. The job needs `permissions: id-token: write`. Without it the action can't mint the OIDC token Sigstore needs to issue a cert.
-- **`cosign verify-blob`** fails with cert-identity mismatch. The default `--certificate-identity-regexp '.*'` is permissive (any cert from the OIDC issuer). For stricter verification, replace with the exact subject pattern, e.g. `^https://github.com/GRCEngClub/cgep-app-starter/.github/workflows/grc-gate.yml@refs/heads/main$`.
-- **Rekor propagation race.** The Sigstore Rekor public log can lag the signing call by ~1 second. If you call verify within milliseconds of signing, the log entry isn't there yet. CI naturally waits, this is a laptop-only race.
-- **Object Lock rejects overwrite.** The bundle key includes `runs/<run_id>` so each run lands at a unique key. If you re-run a job and the `RUN_ID` is reused for some reason, you'll get a 403 on the second `s3 cp`. Trigger a fresh run instead.
-- **`shasum: command not found`.** Linux ships `sha256sum`, macOS ships `shasum -a 256`. The reference script uses `shasum -a 256`. Swap to `sha256sum` on Linux runners if you adapt this for non-GitHub CI.
+- [ ] At least one run's full signed bundle visible in the vault.
+- [ ] `evidence/lab-4-4/receipt.json` committed (copied from the signing step).
+- [ ] A `WRITEUP.md` section mapping each of the four chain properties to the artifact that proves it.
 
 ## Cleanup
 
-Don't clean the vault. The whole point of a 365-day-retention vault is that the evidence outlives the PR that produced it. For lab purposes (Lab 2.5 deployed it in GOVERNANCE 1-day mode), the bundles will become deletable in 24 hours. Production: COMPLIANCE mode, longer retention, no clean.
+Don't clean the vault on purpose; the point of retention is that evidence outlives the PR that made it. Because Lab 2.5 deployed the vault in GOVERNANCE mode with 1-day retention, the lab bundles become deletable after 24 hours on their own, and you can then `terraform destroy` the vault. In production you'd use COMPLIANCE mode and a long retention, and you would never clean it.
+
+## Troubleshooting
+
+- **`cosign sign-blob: failed to get OIDC token` in CI.** The job needs `permissions: id-token: write`. Without it Sigstore can't issue a certificate.
+- **`cosign verify-blob` fails on certificate identity.** The script uses a permissive `--certificate-identity-regexp '.*'`. For stricter checks, replace it with the exact workflow subject, for example `^https://github.com/OWNER/REPO/.github/workflows/grc-gate.yml@refs/heads/main$`.
+- **Rekor lag.** The public transparency log can trail the signing call by about a second. Verifying microseconds after signing can miss the entry. CI naturally waits; this only bites on a laptop loop.
+- **403 on the second upload.** Object Lock blocks overwriting an existing key. Each run lands under a unique `runs/<run_id>` prefix, so a fresh run avoids this; don't reuse a run ID.
+- **`Need sha256sum or shasum`.** Neither hashing tool is on your PATH. Git Bash and Ubuntu include `sha256sum`; macOS includes `shasum`. Confirm with `command -v sha256sum` or `command -v shasum`.
 
 ## How this feeds the capstone
 
-Every PR in your capstone repo now leaves behind a signed, timestamped, immutably-stored record of what was tested and what happened. An assessor who never meets you can reconstruct the chain in minutes:
-
-1. Read your OSCAL component (Lab 6.1).
-2. Follow the evidence URI to a specific object in the vault.
-3. Run `verify-evidence.sh` against the run ID.
-4. See `CHAIN INTACT`.
-
-That is the engineered assurance the capstone is asking you to demonstrate. You just shipped it.
+Every PR in your capstone repo now leaves a signed, timestamped, immutably-stored record of what was tested and what happened. An assessor who never speaks to you can reconstruct the whole chain: read your OSCAL component (Chapter 6), follow its evidence link to a vault object, run `verify-evidence.sh` against the run ID, and see `CHAIN INTACT`. That is the engineered assurance the capstone asks you to demonstrate, and you've now built every piece of it.

--- a/guides/05_02_aws_security_services.md
+++ b/guides/05_02_aws_security_services.md
@@ -1,55 +1,132 @@
 # Lab 5.2: AWS Security Services Baseline
 
-CloudTrail records what happened. Config records what the resource looked like. Security Hub aggregates findings into one normalized view. Together they're the AWS-native compliance backbone, the layer that keeps producing evidence after you stop pushing PRs. This lab stands them up via Terraform and captures the first wave of findings.
+So far your evidence has come from pull requests. But compliance doesn't stop when you stop pushing code. This lab stands up the AWS-native services that keep producing evidence continuously: CloudTrail records every action taken in your account, AWS Config records what each resource looked like over time, and Security Hub gathers findings from across the account into one normalized list mapped to NIST controls. Together they're the always-on backbone underneath the pipeline you built in Chapter 4.
 
-## Learning objectives
+For the GRC folks, these three services are where "continuous monitoring" stops being a phrase and starts being a JSON feed you can hand an auditor. For the technical folks, this is standing up account-level security tooling with Terraform, with the goal of producing evidence rather than dashboards.
 
-- Deploy a multi-region CloudTrail with log-file validation, mapped to AU-2, AU-12, AU-10.
-- Enable Security Hub with the NIST 800-53 Rev 5 standard subscribed.
-- Pull Security Hub findings as a JSON evidence artifact and route them into your audit trail.
+## Before you begin
 
-## Prerequisites
+If this is your first lab, set up [your tools](../getting-started/tools.md) and [your repo](../getting-started/repo-structure.md) first.
 
-- AWS account where you have admin or near-admin rights. Examples below use `--profile <your-sandbox>`; substitute yours.
-- Terraform `>= 1.6`.
-- The account has not already enabled Security Hub on a paid tier you don't want to disturb. Check with `aws securityhub describe-hub`.
+You need an AWS account where you have admin or near-admin rights, and Terraform `>= 1.6`. Check whether Security Hub is already on before you start, so you don't disturb an existing setup: `aws securityhub describe-hub --profile default`. Commands in this lab use `--profile default`; if you named your profile something else in Lab 2.3, replace `default` with that name.
 
-## Estimated time & cost
+This lab is self-contained: it deploys its own baseline and doesn't depend on any earlier lab's live resources.
 
-THIS LAB COSTS REAL MONEY. Read this section before applying.
+## Time and cost: read this first
 
-- CloudTrail: management events are free. We do not enable data events here.
-- Security Hub: about $0.001 per security check per month. The NIST 800-53 standard runs ~300 checks. A single-account lab with no compute racks up under $1 per month.
-- AWS Config: about $2 per month per recorder + $0.001 per rule evaluation. Many Security Hub controls require Config to be enabled to evaluate. The reference walkthrough in this lab does NOT deploy Config because it's blocked by an org-level SCP in the test account. The Terraform code for Config is included for learners who can deploy it.
+> **This lab costs real money.** Unlike every lab before it, the services here bill while they run. Read this before you apply.
 
-If you destroy within an hour of applying, expect under $1 charged. Leaving Security Hub running for a month with NIST and FSBP standards in a single quiet account is on the order of $5-8.
+- **CloudTrail:** management events are free, and this lab doesn't enable the paid data events.
+- **Security Hub:** roughly $0.001 per security check per month. The NIST 800-53 standard is about 300 checks, so a quiet single-account lab is under $1/month, but a month of leaving it on with multiple standards is more like $5 to $8.
+- **AWS Config:** about $2/month per recorder plus a tiny per-evaluation charge. This lab treats Config as optional, partly for cost and partly because org accounts often block it (more below).
+
+If you destroy within an hour of applying, expect under $1 total. The single highest-impact thing you can do to stop ongoing cost is to unsubscribe the Security Hub standards, since Hub itself is free and the standards' checks are what bill. Budget 60 to 90 minutes, most of it waiting for findings to populate.
 
 ## Architecture
 
 ```
-   us-east-1 (and every other region)
-   ──────────────────────────────────
-   CloudTrail (multi-region, mgmt events) ─▶ S3 bucket (logs)
-        AU-2 / AU-12 / AU-10 (file-validation)
+   CloudTrail (multi-region, mgmt events)  ─▶  S3 bucket (logs)
+        AU-2 / AU-12 / AU-10 (log-file validation)
 
-   AWS Config recorder ─▶ S3 bucket (config items)        (optional: SCP may block)
+   AWS Config recorder ─▶ S3 bucket          (optional; an org SCP may block it)
         CM-2 / CM-6 / CM-8
 
-   Security Hub (NIST 800-53 + FSBP) ◀─ findings from Config + GuardDuty + native checks
+   Security Hub (NIST 800-53 + FSBP)  ◀─ findings from Config, GuardDuty, native checks
         RA-5 / SI-4
 ```
 
+## Why native baselines instead of a shiny vendor tool
+
+Plenty of vendors will sell you a polished security console. CloudTrail, Config, and Security Hub are already inside the platform you're paying for, they're mapped to the same NIST controls an auditor will ask about, and they emit JSON you can pipe straight into the pipeline you already built. They aren't beautiful. They're durable, and they're the ones the assessor already trusts. For compliance evidence, durable wins.
+
 ## Step-by-step walkthrough
 
-### Concept: Why baseline services beat point tools
+### Where these files live
 
-Every cloud security vendor will sell you a slick console. CloudTrail, Config, and Security Hub are inside the platform you're already paying for, mapped to the same NIST controls auditors ask about, and producing JSON you can pipe into your existing pipeline. They aren't pretty. They're durable. Pick the durable one.
+Account-level baselines are conceptually distinct from the deployable primitives and reusable modules, so they get their own area:
 
-### Step 1 CloudTrail
+```
+cgep-labs/
+├── terraform/
+│   └── baselines/
+│       └── aws/
+│           ├── main.tf
+│           ├── cloudtrail.tf
+│           ├── security_hub.tf
+│           ├── variables.tf
+│           ├── outputs.tf
+│           └── README.md
+└── evidence/lab-5-2/
+    └── security-hub-findings.json   ← filled in when you capture evidence
+```
 
-Multi-region, with log-file validation on (AU-10). The bucket policy must scope the `aws:SourceArn` condition to the trail you're about to create.
+### Scaffold this lab's empty files
+
+Run this once from the repo root (`cgep-labs`). It creates every path in the diagram above as an empty file so the later steps are "open and paste," not "guess where this goes."
+
+```bash
+# from the repo root
+mkdir -p terraform/baselines/aws evidence/lab-5-2
+
+touch \
+  terraform/baselines/aws/main.tf \
+  terraform/baselines/aws/cloudtrail.tf \
+  terraform/baselines/aws/security_hub.tf \
+  terraform/baselines/aws/variables.tf \
+  terraform/baselines/aws/outputs.tf \
+  terraform/baselines/aws/README.md
+
+find terraform/baselines/aws evidence/lab-5-2 -type f | sort
+
+# Most of the steps below edit files in this folder:
+cd terraform/baselines/aws
+ls
+```
+
+### Step 0: The connective scaffolding
+
+The service files below reference a provider, a random suffix, and your account ID. Open **`terraform/baselines/aws/main.tf`** and **`terraform/baselines/aws/variables.tf`** first (the original lab assumed these; they're spelled out here so the baseline applies cleanly).
 
 ```hcl
+# terraform/baselines/aws/main.tf
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    aws    = { source = "hashicorp/aws", version = "~> 5.0" }
+    random = { source = "hashicorp/random", version = "~> 3.6" }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = {
+      Project         = "cgep-lab"
+      Environment     = "baseline"
+      ManagedBy       = "terraform"
+      ComplianceScope = "cge-p-lab"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+resource "random_id" "suffix" { byte_length = 4 }
+```
+
+```hcl
+# terraform/baselines/aws/variables.tf
+variable "aws_region" {
+  type    = string
+  default = "us-east-1"
+}
+```
+
+### Step 1: CloudTrail
+
+A multi-region trail with log-file validation. The bucket policy scopes the `aws:SourceArn` condition to exactly the trail you're about to create, which is the part people most often get wrong. Open **`terraform/baselines/aws/cloudtrail.tf`** and paste:
+
+```hcl
+# terraform/baselines/aws/cloudtrail.tf
 resource "aws_s3_bucket" "trail" {
   bucket        = "cgep-lab-cloudtrail-${random_id.suffix.hex}"
   force_destroy = true
@@ -123,13 +200,14 @@ resource "aws_cloudtrail" "mgmt" {
 }
 ```
 
-`enable_log_file_validation = true` makes CloudTrail emit a digest file every hour signed by an AWS-managed key. Your auditor can use it to detect tampering. That's AU-10 (integrity of audit information) for free.
+The single most valuable line is `enable_log_file_validation = true`. It makes CloudTrail emit an hourly digest file signed by an AWS-managed key, which an auditor can use to detect after-the-fact tampering with the logs. That's AU-10, integrity of audit information, handed to you for free.
 
-### Step 2 Security Hub
+### Step 2: Security Hub
 
-Two standards subscribed: NIST 800-53 Rev 5 and AWS Foundational Security Best Practices. Both are free to subscribe to; you pay per security check.
+Subscribe to two standards: NIST 800-53 Rev 5 and AWS Foundational Security Best Practices. Subscribing is free; you pay per check. Open **`terraform/baselines/aws/security_hub.tf`** and paste:
 
 ```hcl
+# terraform/baselines/aws/security_hub.tf
 resource "aws_securityhub_account" "this" {}
 
 resource "aws_securityhub_standards_subscription" "nist_800_53" {
@@ -143,123 +221,134 @@ resource "aws_securityhub_standards_subscription" "fsbp" {
 }
 ```
 
-If Security Hub is already enabled in the account from a previous experiment or org baseline, terraform apply will hit `ResourceConflictException`. Import it instead:
+If Security Hub is already enabled in the account, `apply` will fail with `ResourceConflictException`. Import the existing one instead of fighting it:
 
 ```bash
-terraform import aws_securityhub_account.this <ACCOUNT_ID>
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --profile default)
+terraform import aws_securityhub_account.this "$ACCOUNT_ID"
 ```
 
-### Step 3 AWS Config (may be SCP-blocked)
+### Step 3: AWS Config (optional, often blocked)
 
-The reference Terraform includes a Config recorder + delivery channel + IAM role + bucket. Org-managed accounts often have an SCP like:
-
-```
-"Effect": "Deny", "Action": "config:*"
-```
-
-scoped to non-management accounts. If your `terraform apply` returns:
+Config is the third service, but in org-managed accounts it's frequently centralized and blocked for member accounts by a service control policy that denies `config:*`. If you try to deploy a Config recorder and see:
 
 ```
-AccessDeniedException: User ... is not authorized to perform: config:PutConfigurationRecorder
-on resource ... with an explicit deny in a service control policy
+AccessDeniedException: ... not authorized to perform: config:PutConfigurationRecorder
+... with an explicit deny in a service control policy
 ```
 
-then Config is centrally managed in your org and the lab's Terraform should be commented out for now. The cleanest reference signal Security Hub gives you when Config is missing is a CRITICAL finding titled:
+then Config is managed elsewhere in your org, and you should leave it out of this lab. Here's the elegant part: when Config is missing, Security Hub raises a CRITICAL finding titled "AWS Config should be enabled and use the service-linked role for resource recording." That finding *is* evidence. Your account is reporting on its own gap, in machine-readable form, without you writing a word. For a GRC engineer, a system that documents its own deficiencies is exactly the goal.
 
-> "AWS Config should be enabled and use the service-linked role for resource recording"
+### Step 4: Add outputs, then apply and wait
 
-That finding is its own evidence: your account is reporting on its own gap.
+Open **`terraform/baselines/aws/outputs.tf`** so verify commands can pull names without copy-pasting:
 
-### Step 4 Apply and wait
+```hcl
+# terraform/baselines/aws/outputs.tf
+output "trail_name" {
+  value       = aws_cloudtrail.mgmt.name
+  description = "CloudTrail name for verify commands."
+}
+
+output "trail_bucket" {
+  value       = aws_s3_bucket.trail.id
+  description = "S3 bucket receiving CloudTrail logs."
+}
+
+output "securityhub_account_id" {
+  value       = aws_securityhub_account.this.id
+  description = "Account ID Security Hub is enabled in (also the terraform import id)."
+}
+```
 
 ```bash
-eval "$(aws configure export-credentials --profile <your-sandbox> --format env)"
+# you should already be in terraform/baselines/aws from the mkdir above
+eval "$(aws configure export-credentials --profile default --format env)"
 terraform init
 terraform apply -auto-approve
 ```
 
-Wait 10 to 20 minutes. Security Hub findings populate slowly on first deploy.
+Then wait 10 to 20 minutes. Security Hub populates its first findings slowly, so an empty result right after apply is normal, not a failure.
 
-### Step 5 Verify
+### Step 5: Verify
 
 ```bash
-aws cloudtrail get-trail-status --name cgep-lab-mgmt --region us-east-1 \
+TRAIL=$(terraform output -raw trail_name)
+
+aws cloudtrail get-trail-status --name "$TRAIL" --region us-east-1 \
+  --profile default \
   --query '{IsLogging:IsLogging,LatestDeliveryTime:LatestDeliveryTime}'
 # Expect IsLogging: true
 
-aws securityhub describe-hub --region us-east-1 --query HubArn
+aws securityhub describe-hub --region us-east-1 --profile default --query HubArn
 # Expect arn:aws:securityhub:us-east-1:ACCOUNT:hub/default
 
-aws securityhub get-findings --region us-east-1 --max-results 5 \
+aws securityhub get-findings --region us-east-1 --profile default --max-results 5 \
   --query 'Findings[?Severity.Label==`CRITICAL`].{Title:Title,GeneratorId:GeneratorId}' \
   --output json
 ```
 
-Reference run output (after Security Hub had been enabled for a few minutes):
+A freshly-deployed account typically shows somewhere between 1 and 50 findings within the first hour, mostly account-level controls like CloudTrail configuration, the root account, and the password policy. One of the first you'll likely see is the "AWS Config should be enabled" finding from Step 3.
 
-```json
-[
-  {
-    "Title": "AWS Config should be enabled and use the service-linked role for resource recording",
-    "GeneratorId": "security-control/Config.1"
-  }
-]
-```
-
-In a freshly-deployed account, expect anywhere from 1 to ~50 findings within an hour. The first batch is mostly account-level controls (CloudTrail config, root account, password policy).
-
-### Step 6 Capture findings as evidence
+### Step 6: Capture findings as evidence
 
 ```bash
-mkdir -p evidence/lab-5-2
-aws securityhub get-findings --region us-east-1 --max-results 50 \
-  > evidence/lab-5-2/security-hub-findings.json
-
-wc -c evidence/lab-5-2/security-hub-findings.json
-# 25KB or so for a small account
+# still inside terraform/baselines/aws — climb to the repo root's evidence folder
+mkdir -p ../../../evidence/lab-5-2
+aws securityhub get-findings --region us-east-1 --profile default --max-results 50 \
+  > ../../../evidence/lab-5-2/security-hub-findings.json
 ```
 
-This file is what your Lab 4.4 capture-evidence step uploads to your vault. The capstone's OSCAL component points at signed copies of files like this for control statements about continuous monitoring.
+This JSON is exactly the kind of artifact your Lab 4.4 signing step uploads to the vault. In Chapter 6 your OSCAL component points at a signed copy of a file like this as its evidence for continuous monitoring.
 
 ## Verification
 
 - `aws cloudtrail get-trail-status` returns `"IsLogging": true`.
 - `aws securityhub describe-hub` returns the hub ARN.
-- `aws securityhub get-findings` returns at least one finding within 30 minutes of enabling.
+- At least one finding appears within 30 minutes.
 - `evidence/lab-5-2/security-hub-findings.json` is captured and non-empty.
 
-## Portfolio submission checklist
+Before you commit, open **`terraform/baselines/aws/README.md`** (scaffolded empty) and map each service to its controls: AU-2/AU-12/AU-10 (CloudTrail), RA-5/SI-4 (Security Hub), CM-2/CM-6/CM-8 (Config, if present).
 
-- [ ] `terraform/baselines/aws/` directory committed with `cloudtrail.tf`, `security_hub.tf`, optionally `config.tf`, plus `main.tf`, `variables.tf`, `outputs.tf`, `README.md`.
-- [ ] README explains which controls each service satisfies (AU-2/AU-12/AU-10 for CloudTrail, RA-5/SI-4 for Security Hub, CM-2/CM-6/CM-8 for Config).
-- [ ] `evidence/lab-5-2/security-hub-findings.json` captured. If you signed it via Lab 2.5's `capture-evidence.sh`, note the vault VersionId in the README.
-
-## Troubleshooting
-
-- **`InsufficientS3BucketPolicyException`** on CloudTrail. The bucket policy is missing the `aws:SourceArn` condition. Both statements above include it; if you adapt them, keep it.
-- **`ResourceConflictException: Account is already subscribed to Security Hub`**. Some other automation enabled it first. `terraform import aws_securityhub_account.this <ACCOUNT_ID>` and re-apply.
-- **`AccessDeniedException ... explicit deny in a service control policy`** for Config. Your account is org-managed and Config is centralized. Comment out the Config resources in the lab's Terraform. The Security Hub finding "AWS Config should be enabled" is itself the evidence that this gap exists.
-- **No findings after 30 minutes.** Security Hub batches the first wave. If you really see nothing, check that the standards subscriptions actually applied: `aws securityhub get-enabled-standards`.
-- **Config recorder name conflict**. Only one recorder per region. If a previous deploy left one, delete the existing recorder before re-applying.
-
-## Cleanup
+## Commit your work
 
 ```bash
-# Capture evidence first.
-aws securityhub get-findings --region us-east-1 --max-results 50 \
-  > evidence/lab-5-2/security-hub-findings.json
+# from the repo root
+git add terraform/baselines/aws evidence/lab-5-2
+git commit -m "Lab 5.2: AWS security services baseline + findings evidence"
+git push
+```
 
-# Detach Security Hub from terraform state if you want to keep it enabled.
-terraform state rm aws_securityhub_account.this
+## Cleanup: tear down promptly to stop the bill
 
-# Destroy the rest (CloudTrail, S3 buckets, IAM, optional Config).
+This is the lab where forgetting to clean up actually costs you, so do it the same day. Capture your evidence first (the commit above already did), then:
+
+```bash
+cd terraform/baselines/aws
+
+# Optional: if you want to leave Security Hub enabled, drop it from state first.
+# Otherwise skip this line and let destroy disable it.
+# terraform state rm aws_securityhub_account.this
+
 terraform destroy -auto-approve
 ```
 
-CloudTrail's bucket has objects (the trail's own logs). `force_destroy = true` in the bucket resource lets terraform delete it. The standards subscriptions take ~15 seconds each to detach.
+The CloudTrail bucket holds the trail's own log objects; `force_destroy = true` lets Terraform empty and delete it. The standards subscriptions take about 15 seconds each to detach. If you only want to stop the cost without tearing everything down, unsubscribing the Security Hub standards is the high-impact move.
 
-If you're worried about ongoing cost, the high-impact action is unsubscribing the Security Hub standards. Hub itself is free; the standards' security checks are what bill.
+## Portfolio submission checklist
+
+- [ ] `terraform/baselines/aws/` committed with `cloudtrail.tf`, `security_hub.tf`, `main.tf`, `variables.tf`, `outputs.tf`, `README.md` (and `config.tf` if your account allowed it).
+- [ ] The README maps services to controls: AU-2/AU-12/AU-10 (CloudTrail), RA-5/SI-4 (Security Hub), CM-2/CM-6/CM-8 (Config).
+- [ ] `evidence/lab-5-2/security-hub-findings.json` captured. If you signed it via the Lab 2.5 capture script, note the vault VersionId in the README.
+
+## Troubleshooting
+
+- **`InsufficientS3BucketPolicyException` on CloudTrail.** The bucket policy is missing the `aws:SourceArn` condition. Both statements above include it; keep them if you adapt the policy.
+- **`ResourceConflictException: Account is already subscribed to Security Hub`.** Something enabled it first. Import with your account ID from `aws sts get-caller-identity` and re-apply.
+- **`explicit deny in a service control policy` for Config.** Your account is org-managed and Config is centralized. Leave Config out; the Security Hub "Config should be enabled" finding is your evidence of the gap.
+- **No findings after 30 minutes.** The first wave is batched. Confirm the subscriptions applied with `aws securityhub get-enabled-standards`.
+- **Config recorder name conflict.** Only one recorder per region. Delete the existing one before re-applying.
 
 ## How this feeds the capstone
 
-Your capstone's OSCAL component (Lab 6.1) declares an `implemented-requirement` for AU-2, AU-9, AU-10, RA-5, and SI-4. The implementation statement names CloudTrail and Security Hub. The evidence URI points at a signed copy of `security-hub-findings.json` in your vault. An assessor follows the chain: catalog -> profile -> component -> evidence URI -> verified bundle. They don't have to log into your AWS console.
+Your capstone's OSCAL component (Chapter 6) declares implemented requirements for AU-2, AU-9, AU-10, RA-5, and SI-4, and names CloudTrail and Security Hub as the implementation. The evidence link points at a signed copy of `security-hub-findings.json` in your vault. An assessor follows the chain from catalog to profile to component to evidence to verified bundle, never once logging into your AWS console. That's the continuous-monitoring half of the assurance story, and it's now standing up on its own.

--- a/guides/05_04_gcp_security_services.md
+++ b/guides/05_04_gcp_security_services.md
@@ -1,58 +1,122 @@
 # Lab 5.4: GCP Security Services Baseline
 
-GCP leads with identity and data. Where AWS gives you a flat IAM policy and a Security Hub aggregator, GCP gives you Org Policy that rejects misconfigurations at the API call, Workload Identity Federation that replaces service account keys with short-lived OIDC tokens, and Data Access logs that, deliberately, you have to turn on. This lab does all three for one project.
+This is the GCP counterpart to Lab 5.2, and the contrast is the lesson. Where AWS gives you an aggregator that *flags* problems after they happen, GCP leans on identity and prevention: Org Policy rejects a misconfigured resource at the moment of the API call, Workload Identity Federation replaces downloadable service-account keys with short-lived tokens, and Data Access logs record reads and writes once you turn them on. You'll set up all three for one project.
 
-## Learning objectives
+For the GRC folks, this is the difference between a detective control (catch it later) and a preventive one (it never happens). For the technical folks, this is GCP's identity-first security model, and you'll recognize WIF as the same OIDC pattern you wired into AWS in Lab 4.3, just on the other cloud.
 
-- Enforce Org Policy at the API so non-compliant resource creation is rejected before it exists.
-- Replace long-lived service account keys with Workload Identity Federation for GitHub Actions.
-- Enable Data Access audit logs for Cloud Storage, Cloud KMS, and IAM (off by default; this is the #1 GCP audit finding).
+## Before you begin
 
-## Prerequisites
+If this is your first lab, set up [your tools](../getting-started/tools.md) and [your repo](../getting-started/repo-structure.md) first.
 
-- A GCP project you own, with billing enabled and APIs `cloudkms.googleapis.com`, `iam.googleapis.com`, and `cloudresourcemanager.googleapis.com` enabled.
-- Roles you need: `roles/orgpolicy.policyAdmin`, `roles/iam.workloadIdentityPoolAdmin`, `roles/logging.admin`. At project scope these can be granted by the project owner; at organization scope you need org-level rights.
-- `gcloud` authenticated for both `gcloud auth login` (interactive) and `gcloud auth application-default login` (Terraform's google provider uses ADC).
+You need:
+
+- A GCP project you own with billing on, and these APIs enabled: `cloudkms.googleapis.com`, `iam.googleapis.com`, `cloudresourcemanager.googleapis.com`, and `orgpolicy.googleapis.com`.
+- Roles: `roles/orgpolicy.policyAdmin`, `roles/iam.workloadIdentityPoolAdmin`, `roles/logging.admin` (a project owner can grant these at project scope).
+- `gcloud` authenticated both ways: `gcloud auth login` and `gcloud auth application-default login` (Terraform reads the second).
 - Terraform `>= 1.6`.
 
-If your project sits inside an Organization and you want to apply Org Policy at the org or folder scope, the same resources below take a different `parent` value. The lab uses project scope so it works in any GCP environment.
+Substitute your project ID for `your-gcp-project` and your GitHub repo (`<your-github-org>/cgep-labs`, or whichever repo will assume the WIF identity) wherever those placeholders appear. This lab is self-contained; it deploys its own baseline and depends on no earlier lab's live resources.
 
-## Estimated time & cost
+## Time and cost
 
-- 75 to 90 minutes the first time, mostly waiting for Org Policy propagation (5-10 minutes per change).
-- Cost: Org Policy is free. WIF is free. Data Access logs cost $0.50/GB ingested + Cloud Logging storage; for an empty project this is pennies. Security Command Center Standard is free; Premium is enterprise-priced and not used in this lab.
+- Time: 75 to 90 minutes, much of it waiting for Org Policy to propagate (5 to 10 minutes per change).
+- Cost: Org Policy and WIF are free. Data Access logs cost about $0.50/GB ingested plus log storage, which is pennies on an empty project. Security Command Center Standard is free; Premium isn't used here.
 
 ## Architecture
 
 ```
    project (your-gcp-project)
    ─────────────────────────
-   Org Policy (project scope, REJECT at API):
+   Org Policy (REJECT at the API call):
      storage.uniformBucketLevelAccess = TRUE      (CM-6)
      iam.disableServiceAccountKeyCreation = TRUE  (AC-2)
      compute.requireOsLogin = TRUE                (AC-3)
 
    Workload Identity Federation:
-     pool: github-actions
-     provider: token.actions.githubusercontent.com
-     attribute_condition: assertion.repository == "GRCEngClub/cgep-app-starter"
-     service_account: cgep-grc-gate-sa@... (roles/viewer)
+     pool + provider trusting GitHub's OIDC
+     bound to one repo via attribute_condition
+     mapped to a read-only service account
 
-   Data Access audit logs (per service):
-     storage.googleapis.com    DATA_READ + DATA_WRITE + ADMIN_READ
-     cloudkms.googleapis.com   DATA_READ + DATA_WRITE + ADMIN_READ
-     iam.googleapis.com        DATA_READ + DATA_WRITE + ADMIN_READ
+   Data Access audit logs (per service, off by default):
+     storage / cloudkms / iam  →  DATA_READ + DATA_WRITE + ADMIN_READ
 ```
+
+## Why identity-first
+
+GCP's bet is that the smallest unit of security is the principal, not the resource. Org Policy enforces at the API, so a bucket creation that violates a constraint is rejected outright rather than flagged after the fact. WIF replaces the old "make a service account, download a JSON key, paste it into GitHub secrets, pray it never leaks" dance with "the workflow presents a short-lived OIDC token, GCP swaps it for a temporary access token, the token expires on its own." Together they make whole categories of attack simply not worth attempting.
 
 ## Step-by-step walkthrough
 
-### Concept: Why identity-first
+### Where these files live
 
-GCP's bet is that the smallest unit of security is the principal, not the resource. Org Policy enforces at the API call: a bucket creation attempt that violates `uniformBucketLevelAccess` is REJECTED, not flagged. WIF replaces "create a service account, download a JSON key, paste into GitHub Secrets, hope nobody leaks it" with "the GitHub Actions runtime presents an OIDC token, GCP swaps it for a short-lived access token, the token expires automatically." The two together make whole categories of attack uneconomical.
+```
+cgep-labs/
+├── terraform/baselines/gcp/
+│   ├── main.tf
+│   ├── org_policy.tf
+│   ├── wif.tf          ← also holds the two outputs used in verify/demo
+│   ├── audit_logs.tf
+│   ├── variables.tf
+│   └── README.md
+└── evidence/lab-5-4/
+    └── iam-policy.json   ← filled in when you capture evidence
+```
 
-### Step 1 Org Policy at project scope
+### Scaffold this lab's empty files
+
+Run this once from the repo root (`cgep-labs`). It creates every path in the diagram above as an empty file so the later steps are "open and paste," not "guess where this goes."
+
+```bash
+# from the repo root
+mkdir -p terraform/baselines/gcp evidence/lab-5-4
+
+touch \
+  terraform/baselines/gcp/main.tf \
+  terraform/baselines/gcp/org_policy.tf \
+  terraform/baselines/gcp/wif.tf \
+  terraform/baselines/gcp/audit_logs.tf \
+  terraform/baselines/gcp/variables.tf \
+  terraform/baselines/gcp/README.md
+
+find terraform/baselines/gcp evidence/lab-5-4 -type f | sort
+
+# Most of the steps below edit files in this folder:
+cd terraform/baselines/gcp
+ls
+```
+
+Open **`terraform/baselines/gcp/main.tf`** and **`terraform/baselines/gcp/variables.tf`** first — the snippets below assume these shared pieces:
 
 ```hcl
+# terraform/baselines/gcp/main.tf
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    google = { source = "hashicorp/google", version = "~> 5.0" }
+  }
+}
+
+provider "google" {
+  project = var.gcp_project
+  region  = "us-central1"
+}
+```
+
+```hcl
+# terraform/baselines/gcp/variables.tf
+variable "gcp_project" { type = string }
+variable "github_repo" {
+  type        = string
+  description = "OWNER/REPO that the WIF provider will trust."
+}
+```
+
+### Step 1: Org Policy at project scope
+
+Three constraints, each enforced (rejected) at the API. Open **`terraform/baselines/gcp/org_policy.tf`** and paste:
+
+```hcl
+# terraform/baselines/gcp/org_policy.tf
 resource "google_org_policy_policy" "uniform_bucket_access" {
   name   = "projects/${var.gcp_project}/policies/storage.uniformBucketLevelAccess"
   parent = "projects/${var.gcp_project}"
@@ -81,32 +145,14 @@ resource "google_org_policy_policy" "require_oslogin" {
 }
 ```
 
-`enforce = "TRUE"` is rejection at the API. To audit-only-without-rejection, omit the rules block; the policy is then in "inherited" state and only visible in the policy listing.
+`enforce = "TRUE"` means rejection at the API. (If you wanted audit-only behavior without rejecting, you'd omit the rules block.)
 
-### Step 2 Test the enforcement
+### Step 2: Workload Identity Federation
 
-After apply, intentionally try to violate one:
-
-```bash
-gcloud iam service-accounts keys create /tmp/key.json \
-  --iam-account=YOUR_SA_EMAIL --project=your-gcp-project
-```
-
-Expected response:
-
-```
-ERROR: (gcloud.iam.service-accounts.keys.create) FAILED_PRECONDITION:
-Key creation is not allowed on this service account.
-constraint iam.disableServiceAccountKeyCreation
-```
-
-This is the lesson. The control didn't fire after the fact in a Security Hub finding three hours later. The action didn't happen. That's defense-in-depth's strongest layer.
-
-### Step 3 Workload Identity Federation
-
-Pool, provider, service account, IAM binding. The `attribute_condition` is critical. Without it, ANY GitHub repo on the public internet can use this provider to impersonate your service account.
+Pool, provider, service account, binding. The `attribute_condition` is the line that matters most. Open **`terraform/baselines/gcp/wif.tf`**. Notice both the condition and the IAM binding read `var.github_repo` — set that once at apply time and you don't have to hunt for hardcoded repo strings:
 
 ```hcl
+# terraform/baselines/gcp/wif.tf
 resource "google_iam_workload_identity_pool" "github" {
   workload_identity_pool_id = "github-actions"
   display_name              = "GitHub Actions"
@@ -122,7 +168,7 @@ resource "google_iam_workload_identity_pool_provider" "github" {
     "attribute.actor"      = "assertion.actor"
   }
 
-  attribute_condition = "assertion.repository == \"GRCEngClub/cgep-app-starter\""
+  attribute_condition = "assertion.repository == \"${var.github_repo}\""
 
   oidc { issuer_uri = "https://token.actions.githubusercontent.com" }
 }
@@ -143,12 +189,24 @@ resource "google_service_account_iam_binding" "wif_user" {
   role               = "roles/iam.workloadIdentityUser"
 
   members = [
-    "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/GRCEngClub/cgep-app-starter",
+    "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repo}",
   ]
+}
+
+output "wif_service_account_email" {
+  value       = google_service_account.gha.email
+  description = "Service account email for the Org Policy key-creation demo and for GitHub Actions auth."
+}
+
+output "workload_identity_provider" {
+  value       = google_iam_workload_identity_pool_provider.github.name
+  description = "Full provider resource name for google-github-actions/auth."
 }
 ```
 
-A GitHub Actions workflow then authenticates without keys:
+> **Never loosen the condition.** `var.github_repo` must be your real `OWNER/REPO` (for lab work, your `cgep-labs` fork or the capstone repo you'll call from CI). Without a tight condition, *any* GitHub repository on the public internet could present a token and impersonate your service account. This single line is the GCP equivalent of the scoped `sub` you set in the AWS OIDC trust back in Lab 4.3.
+
+A workflow then authenticates with no key on disk. After you apply, feed it the outputs rather than hand-building the resource names:
 
 ```yaml
 permissions:
@@ -158,19 +216,22 @@ permissions:
 steps:
   - uses: google-github-actions/auth@v2
     with:
+      # terraform output -raw workload_identity_provider
       workload_identity_provider: projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/github-actions/providers/github
+      # terraform output -raw wif_service_account_email
       service_account: cgep-grc-gate-sa@your-gcp-project.iam.gserviceaccount.com
 
   - run: gcloud storage ls
 ```
 
-The token is minted at job start, expires after one hour, never lands on disk. Same security posture as the AWS OIDC pattern in Lab 4.3, different cloud.
+The token is minted when the job starts, expires after an hour, and never touches the filesystem. Same posture as the AWS OIDC pattern, different cloud, which is exactly the portability a GRC engineer wants.
 
-### Step 4 Enable Data Access audit logs
+### Step 3: Enable Data Access audit logs
 
-Off by default. This is the most-cited GCP audit finding because nobody turns them on.
+These are off by default, and that default is the single most common GCP audit finding, because almost nobody turns them on. Open **`terraform/baselines/gcp/audit_logs.tf`** and paste:
 
 ```hcl
+# terraform/baselines/gcp/audit_logs.tf
 resource "google_project_iam_audit_config" "storage" {
   project = var.gcp_project
   service = "storage.googleapis.com"
@@ -196,71 +257,120 @@ resource "google_project_iam_audit_config" "iam" {
 }
 ```
 
-Verify a read shows up:
+### Step 4: Apply once, then test Org Policy enforcement
+
+With `org_policy.tf`, `wif.tf`, and `audit_logs.tf` in place, apply the whole baseline. Refresh Application Default Credentials first if Terraform has started failing auth:
 
 ```bash
-gsutil ls gs://your-test-bucket
-sleep 30  # log delivery latency
-gcloud logging read 'protoPayload.serviceName="storage.googleapis.com" AND \
+# from terraform/baselines/gcp
+gcloud auth application-default login   # only if ADC is stale
+terraform init
+terraform apply -auto-approve \
+  -var="gcp_project=your-gcp-project" \
+  -var="github_repo=<your-github-org>/cgep-labs"
+
+SA_EMAIL=$(terraform output -raw wif_service_account_email)
+```
+
+Give Org Policy a few minutes to propagate, then deliberately try to create a key on the service account you just created:
+
+```bash
+gcloud iam service-accounts keys create /tmp/key.json \
+  --iam-account="$SA_EMAIL" --project=your-gcp-project
+```
+
+Expected:
+
+```
+ERROR: (gcloud.iam.service-accounts.keys.create) FAILED_PRECONDITION:
+Key creation is not allowed on this service account.
+constraint iam.disableServiceAccountKeyCreation
+```
+
+Sit with this for a moment, because it's the whole point of the lab. The control didn't surface three hours later as a finding to triage. The forbidden action simply did not happen. That refusal at the API is the strongest layer in defense-in-depth: there's nothing to remediate because there's nothing to remediate.
+
+Optional: if you already have a GCS bucket in the project, list it and confirm a Data Access log shows up (delivery can take ~30 seconds):
+
+```bash
+gcloud storage ls gs://your-test-bucket
+sleep 30
+gcloud logging read 'protoPayload.serviceName="storage.googleapis.com" AND
   protoPayload.methodName=~"storage.objects.list"' --limit 5 --format=json
 ```
 
-### Step 5 Security Command Center
+### Step 5: Security Command Center (only if you have an Org)
 
-If your project sits in an Organization with Security Command Center enabled, findings flow in automatically. SCC Standard is free at the org level; Premium is enterprise-priced and not used here. The lab does not provision SCC because it requires org admin; if you have it, dump findings as evidence:
+If your project sits in an Organization with Security Command Center on, findings flow in automatically. SCC Standard is free at the org level. This lab doesn't provision it (that needs org admin), but if you have it, dump findings as evidence:
 
 ```bash
-gcloud scc findings list ORG_ID --source=- --format=json > evidence/lab-5-4/scc-findings.json
+gcloud scc findings list ORG_ID --source=- --format=json > ../../../evidence/lab-5-4/scc-findings.json
 ```
 
-For standalone projects without an Org, SCC is unavailable. The Org Policy enforcements above provide the equivalent preventative layer.
+For a standalone project with no Org, SCC isn't available, and the Org Policy enforcements above are your equivalent preventive layer.
 
 ## Verification
 
 ```bash
-# Org Policies in effect
+# still inside terraform/baselines/gcp
 gcloud org-policies list --project=your-gcp-project | grep -E "uniformBucket|disableServiceAccount|requireOsLogin"
 
-# WIF pool exists
 gcloud iam workload-identity-pools list --location=global --project=your-gcp-project
 
-# Data Access logs enabled
-gcloud projects get-iam-policy your-gcp-project --format=json \
-  | python3 -c 'import sys,json; d=json.load(sys.stdin); print(json.dumps(d.get("auditConfigs",[]),indent=2))'
+# gcloud can project just the auditConfigs field — no Python required
+mkdir -p ../../../evidence/lab-5-4
+gcloud projects get-iam-policy your-gcp-project \
+  --format="json(auditConfigs)" \
+  > ../../../evidence/lab-5-4/iam-policy.json
+cat ../../../evidence/lab-5-4/iam-policy.json
 
-# Try a forbidden action
+# the forbidden action should still fail
+SA_EMAIL=$(terraform output -raw wif_service_account_email)
 gcloud iam service-accounts keys create /tmp/k.json \
-  --iam-account=cgep-grc-gate-sa@your-gcp-project.iam.gserviceaccount.com \
+  --iam-account="$SA_EMAIL" \
   --project=your-gcp-project
 # Expect: FAILED_PRECONDITION
 ```
 
-## Portfolio submission checklist
+Before you commit, open **`terraform/baselines/gcp/README.md`** (scaffolded empty) and note the "Data Access logs are off by default" lesson plus which Org Policy constraints you enforced.
 
-- [ ] `terraform/baselines/gcp/main.tf` (or split files) committed.
-- [ ] At least one demo GitHub Actions workflow using WIF, no service account JSON keys anywhere.
-- [ ] `evidence/lab-5-4/iam-policy.json` (output of `get-iam-policy`) capturing the Data Access logs config.
-- [ ] README notes the "Data Access logs are off by default" lesson.
+## Commit your work
 
-## Troubleshooting
-
-- **Org Policy propagation latency.** First-apply changes can take 5-10 minutes to take effect at the API. A test that creates a forbidden bucket *immediately* after `terraform apply` may briefly succeed.
-- **`PERMISSION_DENIED` on `google_iam_workload_identity_pool_provider`.** You need `roles/iam.workloadIdentityPoolAdmin` on the project, not just `Owner`.
-- **WIF `attribute.repository` condition mismatch.** GitHub's `assertion.repository` is the `OWNER/REPO` literal. Spelling, case, and the slash all matter. If your workflow gets opaque `PERMISSION_DENIED` from `auth@v2`, the condition is wrong.
-- **Data Access logs cost.** In a busy project these can ingest GBs/day. Start with a single service (`storage.googleapis.com`) before turning on KMS and IAM.
-- **`google_org_policy_policy` requires the v2 Org Policy API.** Run `gcloud services enable orgpolicy.googleapis.com` if Terraform errors with `policySpec is not supported`.
+```bash
+# from the repo root
+git add terraform/baselines/gcp evidence/lab-5-4
+git commit -m "Lab 5.4: GCP security baseline (org policy, WIF, data access logs)"
+git push
+```
 
 ## Cleanup
 
 ```bash
-terraform destroy -auto-approve
+cd terraform/baselines/gcp
+terraform destroy -auto-approve \
+  -var="gcp_project=your-gcp-project" \
+  -var="github_repo=<your-github-org>/cgep-labs"
 ```
 
-Two notes:
+Two things to know:
 
-1. WIF pools enter a 30-day soft-delete state. They cannot be re-created with the same `workload_identity_pool_id` until the soft-delete expires or you `gcloud iam workload-identity-pools undelete` and then delete again with `--purge`.
-2. Disabling Org Policy enforcement does not retroactively un-enforce existing resources. Buckets you created with uniform access stay that way; the policy just stops blocking new ones.
+1. WIF pools enter a 30-day soft-delete. You can't recreate one with the same `workload_identity_pool_id` until that expires (or you `undelete` and then delete with `--purge`).
+2. Turning off Org Policy enforcement doesn't retroactively change resources you already created. A bucket made with uniform access stays that way; the policy just stops blocking new violations.
+
+## Portfolio submission checklist
+
+- [ ] `terraform/baselines/gcp/` committed (split files or one `main.tf`).
+- [ ] A demo GitHub Actions workflow that authenticates via WIF, with no service-account JSON key anywhere in the repo.
+- [ ] `evidence/lab-5-4/iam-policy.json` capturing the Data Access logs config.
+- [ ] README notes the "Data Access logs are off by default" lesson.
+
+## Troubleshooting
+
+- **Org Policy propagation latency.** First-apply changes can take 5 to 10 minutes. A forbidden action attempted immediately after apply may briefly slip through; wait, then test.
+- **`PERMISSION_DENIED` creating the WIF provider.** You need `roles/iam.workloadIdentityPoolAdmin`, which `Owner` alone doesn't include.
+- **WIF condition mismatch.** `assertion.repository` is the literal `OWNER/REPO`. Case, spelling, and the slash all matter. An opaque `PERMISSION_DENIED` from `auth@v2` usually means the condition doesn't match your repo.
+- **Data Access log cost.** A busy project can ingest gigabytes a day. Start with `storage.googleapis.com` only before enabling KMS and IAM.
+- **`policySpec is not supported`.** Enable the v2 Org Policy API: `gcloud services enable orgpolicy.googleapis.com`.
 
 ## How this feeds the capstone
 
-The WIF pattern from this lab is your AWS-OIDC equivalent for any GCP-touching workflow. If your capstone's pipeline reaches into GCP for any reason, it uses WIF, not keys. The Org Policy enforcements add a preventative layer above your Rego (which is detective). And the Data Access logs feed your OSCAL component's AU-2 implementation statement: enabled per-service, with the IAM policy JSON as evidence.
+WIF is your key-free pattern for any capstone workflow that touches GCP; if the pipeline reaches into GCP, it uses WIF, never a downloaded key. The Org Policy enforcements sit *above* your Rego policies in the defense stack: Rego is detective (it catches a bad plan), Org Policy is preventive (it refuses the bad action). And the Data Access logs feed your OSCAL component's AU-2 statement, enabled per service, with the IAM policy JSON as the evidence behind it.

--- a/guides/06_01_introduction_to_oscal.md
+++ b/guides/06_01_introduction_to_oscal.md
@@ -1,76 +1,104 @@
 # Lab 6.1: Introduction to OSCAL
 
-OSCAL is NIST's machine-readable format for security controls, profiles, components, system security plans, and assessments. The point isn't the format. The point is that an assessor can traverse from a control catalog to a profile to a component to an evidence URI without ever talking to you. The audit becomes a graph traversal. This lab writes the smallest piece of that graph: one component definition, validated by `trestle`, with evidence links pointing at real signed objects in your vault.
+OSCAL is NIST's machine-readable format for security controls, profiles, components, and assessments. Don't get hung up on the format itself; the reason it exists is the interesting part. With OSCAL, an assessor can start at a control catalog, follow a link to a profile, follow another to a component, and follow one more to a piece of evidence, all without ever talking to you. The audit turns into a graph traversal. This lab writes the smallest real piece of that graph: one component definition, validated by a tool called `trestle`, with evidence links that point at the actual signed bundles in your vault.
 
-## Learning objectives
+For the GRC folks, this is your control narrative rewritten so a machine can read it and an assessor can verify it. For the technical folks, this is authoring structured JSON against a strict schema, where the unusual payoff is that your documentation becomes executable: every claim links to evidence that can be checked.
 
-- Author a valid OSCAL Component Definition for a Terraform module.
-- Author a minimal Profile selecting the controls the component implements.
-- Wire evidence URIs to objects in the Lab 2.5 vault, validate the whole chain with `trestle`.
+This is the documentation layer that ties the whole course together. Everything you built (the compliant module, the policies, the pipeline, the signed vault) gets described here in a way an outside assessor can traverse on their own.
 
-## Prerequisites
+## Before you begin
 
-- Python `>= 3.10`.
-- `pip install compliance-trestle` (NIST's OSCAL Python toolkit).
-- Lab 2.3 (or Lab 2.4) module on disk. We'll describe it in OSCAL.
-- Lab 2.5 vault exists, so evidence URIs resolve.
+If this is your first lab, set up [your tools](../getting-started/tools.md) and [your repo](../getting-started/repo-structure.md) first.
 
-## Estimated time & cost
+You need:
 
-- 60 to 75 minutes.
-- Free. OSCAL tooling is open source. No cloud calls beyond fetching the NIST 800-53 catalog.
+- **Python `>= 3.10`** and **compliance-trestle**, NIST's OSCAL Python toolkit. Install it with `pip install compliance-trestle`. For OSCAL background, NIST's official site is https://pages.nist.gov/OSCAL/.
+- The Lab 2.3 (or 2.4) module on disk, since you'll describe it in OSCAL.
+- For the optional traversal at the end, a signed bundle in your Lab 2.5 vault (produced by the Lab 4.4 pipeline). The authoring and validation themselves need no cloud at all.
 
-## Architecture
+## Time and cost
+
+- Time: 60 to 75 minutes.
+- Cost: free. The tooling is open source and the only network call fetches the public NIST catalog.
+
+## The five OSCAL models
+
+A quick map so the vocabulary doesn't trip you:
+
+| Model | What it describes | Built here? |
+|---|---|---|
+| **Catalog** | A library of controls (e.g., NIST 800-53 Rev 5). | No, you link to NIST's published one. |
+| **Profile** | A chosen subset of controls from one or more catalogs. | Yes, a minimal one. |
+| **Component Definition** | How a software component implements specific controls. | Yes, the centerpiece. |
+| System Security Plan (SSP) | A whole system's controls and components. | Capstone stretch goal. |
+| Assessment Plan / Results | What an auditor planned and found. | Out of scope. |
+
+You're building the middle two: a component definition that says "here's what my module does and here's the proof," and a profile that says "here are the controls I'm claiming."
+
+## Where these files live
 
 ```
-   Terraform module                        OSCAL                                Auditor
-   ────────────────                        ─────                                ───────
-   reference/lab-2-3/    ───describes───▶  component-definition.json
-   main.tf, etc.                           ├─ control-implementations            "show me your
-                                           │   source: NIST 800-53 catalog        SC-28 evidence"
-                                           ├─ implemented-requirements
-                                           │   sc-28, ac-3, au-3, cm-6
-                                           │   props: terraform-resource refs
-                                           │   links: rel=evidence, href=s3://
-                                           │
-                                           profile.json (selects sc-28, ac-3, ...)
-                                                                                  ▼
-                                                                           follows href into vault
-                                                                           runs verify-evidence.sh
-                                                                           sees CHAIN INTACT
+cgep-labs/
+├── oscal/                                 ← committed, capstone-shaped layout
+│   ├── components/
+│   │   └── compliant-s3.json              ← copied from trestle at the end
+│   ├── profiles/
+│   │   └── cge-p-minimum.json             ← copied from trestle at the end
+│   └── README.md
+├── evidence/lab-6-1/
+│   └── trestle-validate.txt               ← filled in when you validate
+└── .trestle-work/                         ← local authoring only (gitignored)
+    ├── component-definitions/compliant-s3-v1/component-definition.json
+    └── profiles/cge-p-minimum/profile.json
 ```
+
+### Scaffold this lab's empty files
+
+Run this once from the repo root (`cgep-labs`). It creates the committed layout up front; trestle will create its own working tree in the next step.
+
+```bash
+# from the repo root
+mkdir -p oscal/components oscal/profiles evidence/lab-6-1
+
+touch \
+  oscal/components/compliant-s3.json \
+  oscal/profiles/cge-p-minimum.json \
+  oscal/README.md
+
+grep -qxF '.trestle-work/' .gitignore || echo '.trestle-work/' >> .gitignore
+
+find oscal evidence/lab-6-1 -type f | sort
+```
+
+You will author inside `.trestle-work/` (trestle's native layout), then copy the finished JSON into the empty `oscal/...` files above.
 
 ## Step-by-step walkthrough
 
-### Concept: The five OSCAL models
+### Step 1: Initialize a trestle workspace
 
-| Model | What it describes | Built in this lab |
-|---|---|---|
-| **Catalog** | A library of controls (e.g., NIST 800-53 Rev 5). | No, we link to the NIST-published one. |
-| **Profile** | A subset of controls selected from one or more catalogs. | Yes, minimal. |
-| **Component Definition** | How a software component implements specific controls. | Yes, the centerpiece. |
-| System Security Plan (SSP) | A whole system's controls + components. | Stretch goal for capstone. |
-| Assessment Plan / Results | What the auditor planned, what the auditor found. | Out of scope. |
-
-### Step 1 Initialize a trestle workspace
+Work under a temporary authoring directory so trestle's full layout doesn't collide with the simpler `oscal/components/` and `oscal/profiles/` paths your capstone expects. You'll copy the finished JSON into those paths at the end.
 
 ```bash
+# from the repo root
 pip install compliance-trestle
-mkdir lab-6-1 && cd lab-6-1
+mkdir -p .trestle-work && cd .trestle-work
 trestle init
 ```
 
-You'll get an OSCAL-shaped directory: `catalogs/`, `profiles/`, `component-definitions/`, etc.
+Trestle lays down an OSCAL-shaped directory: `catalogs/`, `profiles/`, `component-definitions/`, and so on. It's opinionated about structure, which is helpful, because the schema is strict and trestle keeps you inside the lines.
 
-### Step 2 Create the component definition skeleton
+### Step 2: Create the component-definition skeleton
 
 ```bash
+# still inside .trestle-work/
 trestle create -t component-definition -o compliant-s3-v1 -x json
 ```
 
-Trestle generates a minimal valid skeleton. Open `component-definitions/compliant-s3-v1/component-definition.json` and replace it with the real document.
+This generates a minimal valid skeleton at **`.trestle-work/component-definitions/compliant-s3-v1/component-definition.json`**. Open that file and replace it with the real document in the next step.
 
-### Step 3 The component definition
+### Step 3: Write the component definition
+
+Open **`.trestle-work/component-definitions/compliant-s3-v1/component-definition.json`**. This document describes your `compliant-s3` module (the one at `terraform/primitives/compliant-s3`) in OSCAL terms: which controls it implements, which Terraform resource enforces each, and where the evidence lives.
 
 ```json
 {
@@ -130,32 +158,34 @@ Trestle generates a minimal valid skeleton. Open `component-definitions/complian
 }
 ```
 
-Add similar `implemented-requirements` for `ac-3`, `au-3`, and `cm-6`. The full reference is in `reference/lab-6-1/component-definitions/compliant-s3-v1/component-definition.json`.
+Then add the same shape of `implemented-requirements` block for `ac-3`, `au-3`, and `cm-6`, each naming the Terraform resource that enforces it and linking to the same signed bundle.
 
-> **Generate UUIDs the right way.** OSCAL requires v4 UUIDs (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx` where `y` is 8/9/a/b). Don't hand-write them. Run `python3 -c "import uuid; print(uuid.uuid4())"` per UUID. `trestle validate` rejects the wrong format with a regex error; this catches you the first time you try.
+Read the `sc-28` block slowly, because it's the whole idea in miniature. The `control-id` says which control. The `description` says how the module satisfies it. The `terraform-resource` prop says exactly which line of code does it. And the `links[rel=evidence]` href says where the proof lives. Four facts, machine-readable, and the last one is a live pointer into your vault.
 
-### Step 4 Validate
+> **Generate UUIDs the right way.** OSCAL requires version-4 UUIDs (the `4` and the `8/9/a/b` in specific positions matter). Don't hand-write them, or `trestle validate` will reject them with a regex error. You already need Python for trestle, so this is fine: `python3 -c "import uuid; print(uuid.uuid4())"`. On macOS/Linux you can also use `uuidgen | tr '[:upper:]' '[:lower:]'`.
+
+### Step 4: Validate the component
 
 ```bash
 trestle validate -f component-definitions/compliant-s3-v1/component-definition.json
 ```
 
-Expected:
+You want:
 
 ```
 VALID: Model .../component-definition.json passed the Validator
-to confirm the model passes all registered validation tests.
 ```
 
-### Step 5 The Profile
+If it fails, the message usually points right at the missing or malformed field. The schema is strict but verbose, which works in your favor here.
 
-A profile selects which controls from the catalog this component covers.
+### Step 5: Write the profile
+
+A profile selects which catalog controls you're claiming. Create the skeleton, then open **`.trestle-work/profiles/cge-p-minimum/profile.json`** and replace its contents:
 
 ```bash
+# still inside .trestle-work/
 trestle create -t profile -o cge-p-minimum -x json
 ```
-
-Edit `profiles/cge-p-minimum/profile.json`:
 
 ```json
 {
@@ -180,65 +210,77 @@ Edit `profiles/cge-p-minimum/profile.json`:
 }
 ```
 
-Validate:
-
 ```bash
 trestle validate -f profiles/cge-p-minimum/profile.json
 ```
 
-### Step 6 Resolve the profile against the catalog
+### Step 6: Resolve the profile against the catalog
 
 ```bash
 trestle profile-resolve -n cge-p-minimum -o cge-p-minimum-resolved
 ```
 
-Trestle fetches the NIST catalog, applies your selection, and writes a resolved profile, the flat list of controls your component is responsible for. This is what an SSP would import.
+Trestle fetches the NIST catalog, applies your selection, and writes out a *resolved* profile: the flat list of controls you're responsible for, with their full text pulled in from the catalog. This is the artifact a System Security Plan would import. You've turned "I cover four controls" into a self-contained, machine-readable document.
 
-### Step 7 Demonstrate the traversal
+### Step 7: Walk the traversal yourself
 
-Pick `sc-28` in your component definition. Follow the `links[rel=evidence].href` to the vault. Run Lab 4.4's `verify-evidence.sh`:
+This is the part that makes OSCAL click. Take the `sc-28` requirement, follow its `links[rel=evidence].href` into the vault, and run the verify script from Lab 4.4:
+
+> The command below uses `--profile default`. If you named your AWS CLI profile something else in Lab 2.3, replace `default` with that name.
 
 ```bash
-EVIDENCE_VAULT=<your-vault> bash scripts/verify-evidence.sh <run_id>
+# from the repo root; reuse VAULT/RUN_ID from Lab 4.4 if you still have them
+EVIDENCE_VAULT="$VAULT" bash scripts/verify-evidence.sh "$RUN_ID" --profile default
 ```
 
-`CHAIN INTACT`. The OSCAL document, the catalog reference, the implementation statement, the evidence URI, and the signed bundle in the vault are now linked. An assessor reading the OSCAL can verify your control without you in the room.
+When it prints `CHAIN INTACT`, you've just done what an assessor does: started from a control claim in a document, followed a link to a real artifact, and cryptographically confirmed the artifact is authentic and unaltered. Nobody had to log into a console, and you didn't have to be in the room. (If you're doing this lab standalone without a vault bundle handy, the authoring and validation in Steps 1 through 6 still stand on their own; this step is the live demonstration of the link resolving.)
 
 ## Verification
 
-- `trestle validate` returns `VALID` for the component definition AND the profile.
+- `trestle validate` returns `VALID` for both the component definition and the profile.
 - `trestle profile-resolve` produces a resolved profile.
-- At least one evidence URI in the component definition resolves to a real signed object in your vault.
+- At least one evidence URI in the component definition points at a real signed object in your vault.
+
+## Capture and commit
+
+You're still inside `.trestle-work/`. Validate, then overwrite the empty scaffold files under `oscal/` at the repo root:
+
+```bash
+trestle validate -f component-definitions/compliant-s3-v1/component-definition.json \
+  > ../evidence/lab-6-1/trestle-validate.txt 2>&1
+
+cp component-definitions/compliant-s3-v1/component-definition.json ../oscal/components/compliant-s3.json
+cp profiles/cge-p-minimum/profile.json ../oscal/profiles/cge-p-minimum.json
+
+cd ..   # back to cgep-labs (repo root)
+ls oscal/components oscal/profiles evidence/lab-6-1
+
+# Fill the scaffolded README: which module each component describes and where its evidence lives
+# Open oscal/README.md and write a short note, then:
+git add oscal evidence/lab-6-1 .gitignore
+git commit -m "Lab 6.1: OSCAL component definition + profile + validation"
+git push
+```
 
 ## Portfolio submission checklist
 
 - [ ] `oscal/components/<your-component>.json` validated by trestle.
 - [ ] `oscal/profiles/cge-p-minimum.json` validated.
-- [ ] `evidence/lab-6-1/trestle-validate.txt`, the output of `trestle validate`, captured.
-- [ ] README in `oscal/` explaining which module each component describes and where the evidence lives.
+- [ ] `evidence/lab-6-1/trestle-validate.txt` captured.
+- [ ] A README in `oscal/` saying which module each component describes and where its evidence lives.
 
 ## Troubleshooting
 
-- **`string does not match regex` on UUIDs.** OSCAL strictly requires v4. Use `python3 -c "import uuid; print(uuid.uuid4())"`. Don't hand-write.
-- **`trestle validate`** fails on missing required fields. Use `trestle describe -t component-definition -n <name>` to inspect the schema requirements; the schema is strict and helpfully verbose.
-- **Evidence URIs that don't resolve.** OSCAL itself doesn't validate that hrefs resolve. A broken URI is silently a useless attestation. Wire your CI to verify the references during the resolve step, or write a small script.
-- **Catalog imports fail.** NIST's GitHub URLs sometimes change. Anchor to a tag (`/blob/v5.0.0/`) instead of `main` if you want stability.
-- **Different OSCAL versions don't compose.** Catalog and profile and component must all share an `oscal-version`. Trestle pins to whatever version it installed; check with `trestle version`.
+- **`string does not match regex` on a UUID.** OSCAL requires v4 UUIDs. Generate them with `python3 -c "import uuid; print(uuid.uuid4())"` (or `uuidgen`), never by hand.
+- **Validation fails on a missing field.** Run `trestle describe -t component-definition -n <name>` to see what the schema expects; it's strict but the errors are specific.
+- **An evidence URI that doesn't resolve.** OSCAL won't check that hrefs actually resolve, so a broken link is a silently useless attestation. Wire a small check into CI (or your resolve step) that confirms each evidence href points at a real vault object.
+- **Catalog import fails.** NIST's `main`-branch URLs occasionally move. Pin to a tag (e.g., `/v5.0.0/`) for stability.
+- **Version mismatch.** The catalog, profile, and component must share an `oscal-version`. Check what trestle installed with `trestle version` and match it.
 
 ## Cleanup
 
-OSCAL is YAML/JSON in your repo. There's nothing in the cloud to destroy. Commit and move on.
+OSCAL is just JSON in your repo. There's nothing in the cloud to tear down. Commit and move on.
 
 ## How this feeds the capstone
 
-This component definition is the OSCAL layer of your capstone. The capstone's repo holds:
-
-```
-oscal/
-  components/<your-component>.json      # describes what you built
-  profiles/cge-p-minimum.json           # selects the controls you implement
-```
-
-The component definition's `links[rel=evidence].href` points at the latest signed bundle in your vault, written by the Lab 4.3+4.4 pipeline. The chain ends in the vault.
-
-A grader reading your `WRITEUP.md` is told to start at `oscal/components/`. They follow the chain to the vault. They run `verify-evidence.sh`. They see `CHAIN INTACT`. That's the engineered assurance demonstration the capstone is asking for. You just shipped it.
+This component definition *is* your capstone's OSCAL layer. The capstone repo carries `oscal/components/<your-component>.json` (what you built) and `oscal/profiles/cge-p-minimum.json` (the controls you claim), and the component's evidence links point at the latest signed bundle in your vault, written by your Lab 4.3 + 4.4 pipeline. The chain ends in the vault. A grader is told to start at `oscal/components/`, follow the links, run `verify-evidence.sh`, and see `CHAIN INTACT`. That single traversal is the entire course demonstrated end to end, and you've now built every link in it.

--- a/guides/07_01_capstone_brief.md
+++ b/guides/07_01_capstone_brief.md
@@ -4,6 +4,8 @@ You've reached the capstone. Everything you've learned in this course (IaC, poli
 
 You ship the repo, you pass the capstone.
 
+This brief is the contract: it defines what's graded and how. For a walkthrough of *assembling* the repo from your lab artifacts, with a worked layout and a write-up scaffold, see the [Capstone Companion](07_02_capstone_companion.md).
+
 ## The on-ramp: labs are optional, encouraged, and the same skills
 
 The capstone tests the same skills the chapter labs taught. The labs are optional. They are also strongly encouraged. Every lab produces an artifact you can carry directly into your capstone repo.

--- a/guides/07_02_capstone_companion.md
+++ b/guides/07_02_capstone_companion.md
@@ -1,0 +1,203 @@
+# Capstone: Assemble Your Evidence Pipeline
+
+> **This is the how-to, not the contract.** The graded requirements, deliverables, and scoring live in the [Capstone Brief](07_01_capstone_brief.md). Read that first. This companion walks you through assembling the work, lab by lab.
+
+This is where everything converges. The capstone isn't a new topic; it's the integration of every skill the course taught into one repository you own. If you did the labs, the most important thing to understand before you start is this: you are not building from scratch, you are *assembling*. Each lab handed you a piece, and the capstone is where they snap together into a system that produces audit-grade evidence on every push, automatically.
+
+This companion doesn't rewrite the brief. The brief (the `Capstone Project Brief`) is the authoritative spec, and you should read it in full. What this page does is make the brief navigable for someone who's new to either the GRC side or the engineering side: it translates the scenario, makes the choices you have to defend legible, shows you how your lab artifacts assemble into the final repo, and scaffolds the write-up that's worth a large share of your score.
+
+## The mindset shift: you're integrating, not inventing
+
+The single most common way capstones go wrong is treating it like a from-scratch sprint and trying to build a huge new system in 30 days. The brief is explicit that the opposite wins: a small, cleanly integrated repo beats a large, bolted-together one. Your job isn't to add the most resources. It's to take a working application that *isn't* audit-defensible and wrap it in a system that makes it defensible and keeps it that way. If you did the labs, you've already built every layer of that system once. The capstone is the version where they all talk to each other.
+
+## Step zero: the deploy gate
+
+Before any governance work, you have to get the starter application running in your own AWS sandbox. This is a real gate, not a formality: a GRC engineer inherits working systems, and proving you can stand one up is the floor.
+
+> The commands below use `AWS_PROFILE=default`. If you named your AWS CLI profile something else in Lab 2.3, replace `default` with that name.
+
+```bash
+git clone https://github.com/GRCEngClub/cgep-app-starter
+cd cgep-app-starter
+make deploy AWS_PROFILE=default
+make test   AWS_PROFILE=default
+```
+
+`make deploy` provisions the starter's infrastructure (the Patient Intake API and its supporting resources) into your account. `make test` exercises it. If `make test` returns something like `{"submission_id": "...", "status": "received"}`, the application is live and you have something to govern. If it doesn't, stop and fix that first. Everything downstream assumes a working system underneath.
+
+Fork the starter (don't just clone it) so your capstone repo is a clear derivative with its own history, which is where your two graded pull requests will live.
+
+## The scenario, in plain terms
+
+You're the first GRC engineer at a 50-person telehealth company. Engineering shipped a Patient Intake API that works but can't survive an audit. The CTO wants it audit-defensible in 30 days, *without* slowing engineering down. That last clause is the whole philosophy of the course: governance that runs as automated checks in the pipeline instead of as meetings and tickets. The starter ships with eight intentional, named gaps (listed in `GAPS.md` in the starter repo). Your work is to design a system that closes them and proves they stay closed.
+
+## Decision 1: pick your primary framework
+
+The company is chasing three compliance flags at once, and you must pick exactly one as your primary framework, then structure everything beneath it around that choice and defend the choice in your write-up. You don't need deep expertise in any of them to choose well; you need to understand what each is *for*. The starter's `FRAMEWORKS.md` has the primers; here's the orientation:
+
+- **HIPAA Security Rule** is about protecting health information (PHI). Because this is a telehealth company handling patient data, it's the most natural fit for the scenario, and its safeguards map cleanly onto the encryption, access-control, and audit-logging work you've already done. If you're newer to compliance, this is often the most defensible pick precisely because the connection to the system is obvious.
+- **SOC 2 Type II** is about demonstrating, over a period of time, that your controls operate effectively. Its Trust Services Criteria (security, availability, confidentiality, and so on) are broad and very common in enterprise sales. Choose this if you want to emphasize the *continuous* nature of your evidence pipeline, since SOC 2 Type II is fundamentally about controls working over time, which is exactly what your signed-evidence-on-every-push design proves.
+- **CMMC Level 2** is about protecting controlled information for federal work, and it leans heavily on NIST 800-53 / 800-171 control families, the same families your Rego policies already cite. Choose this if you want the tightest mapping between your existing control IDs and the framework's requirements.
+
+There's no wrong choice, only an undefended one. The graders score your *reasoning*, not your framework. Pick the one you can argue for in three sentences, and make sure your OSCAL component's `source` field points at that framework's catalog, because they check that the framework you declare and the framework your OSCAL cites are the same.
+
+## The four layers, and the labs that built them
+
+The repo has four layers, each mapping to a chapter you've completed. For each, here's what "done" looks like and which of your own lab artifacts you carry in.
+
+**Layer 1, the Terraform baseline.** You wrap the starter with the GRC infrastructure that makes it defensible: KMS keys you own (with rotation), an Object Lock evidence bucket, a multi-region CloudTrail, and the specific hardening overrides that close the gaps. The discipline from Lab 2.4 (wrap your KMS + S3 hardening as a reusable module), the hardening pattern from Lab 2.3, the vault from Lab 2.5, and the CloudTrail baseline from Lab 5.2 all land here. Crucial constraint from the brief: use the starter's existing VPC, don't build a second one. Closing the VPC gap means moving the starter's Lambda *into* the VPC it already created, not standing up new networking.
+
+**Layer 2, the OPA policy suite.** Five or more Rego policies enforcing controls from your declared framework, each with a metadata block, each with passing and failing tests, and each catching a *real* gap from `GAPS.md` rather than a generic tag check. Your Lab 3.3 library is the starting point and your Lab 3.4 AWS variants and `policy-gate.sh` are the machinery (the gate uses Conftest's exit codes directly — keep that pattern when you extend the script for your framework). The graders will reintroduce one of your fixed gaps and confirm your gate fires, so your policies have to catch real misconfigurations, not just check for labels.
+
+**Layer 3, the GitHub Actions pipeline.** One workflow with five named steps in order: plan, policy-check, apply-on-merge, sign, upload. This is your Lab 4.3 workflow with the Lab 4.4 signing and upload steps added. The capstone asks for one thing the labs didn't: an actual *apply* on merge to `main`, so the pipeline doesn't just check, it deploys. Two pull requests must exist in your history, one that passed and merged and one that failed the gate and was blocked. Those two PRs are how you prove the gate has teeth.
+
+**Layer 4, the OSCAL component.** One `component-definition.json` describing what you actually built, with real UUIDs, a `source` pointing at your declared framework's catalog, implementation statements referencing real Terraform addresses or ARNs, and evidence links that resolve to real signed objects in your vault, plus a profile selecting your controls. This is your Lab 6.1 component with its controls swapped for your framework's, re-validated with `trestle`. The brief is blunt: if the OSCAL describes a system you didn't build, the layer fails, and they check.
+
+## The decisions you make and defend
+
+Beyond the framework, the brief leaves a handful of choices to you. These aren't busywork; each is a real engineering trade-off, and naming the trade-off is how you defend it. Here's each one in plain terms so you can decide with confidence:
+
+- **AWS region.** Mostly free choice; pick one and be consistent. If your framework or scenario implies data-residency requirements, note that as your reason.
+- **Object Lock mode: COMPLIANCE or GOVERNANCE.** COMPLIANCE means *nobody*, not even the account root, can delete evidence before retention expires, which is the strongest possible chain-of-custody claim but means you can't clean up. GOVERNANCE lets a privileged caller bypass the lock, which is friendlier for a 30-day project. Either is defensible; the strong answer explains the trade-off (tamper-resistance versus operational flexibility) rather than just picking.
+- **Apply on merge, or apply after a manual approval gate.** Auto-apply on merge is fully continuous but gives the pipeline real deploy power. A post-merge manual gate keeps a human in the loop before production changes. Defend based on how much you trust the gate and the blast radius of a bad apply.
+- **Single account or a separate evidence-vault account.** A separate account for the vault is cleaner (the evidence lives outside the account being audited, so an account compromise can't quietly rewrite it), but a single account is acceptable for 30 days. If you go single-account, say so and note what you'd change for production.
+- **Which gaps to close in Terraform versus enforce only in policy.** Some gaps you fix in the infrastructure itself; others you might leave as a policy that blocks any future reintroduction. Both are valid. The interesting write-up explains why a given gap belongs in one bucket versus the other.
+
+The pattern across all of these: the graders reward clear reasoning over any particular answer. A defended GOVERNANCE vault beats an undefended COMPLIANCE one.
+
+## A worked repo layout
+
+Here's how your lab artifacts assemble into the capstone repo. If you've been building in the canonical `cgep-labs` structure throughout the course, most of this is copy-and-adapt rather than write-from-scratch.
+
+```
+your-cgep-capstone/                 (fork of cgep-app-starter)
+├── terraform/
+│   ├── <starter's existing app resources>     # keep these; they're the workload
+│   ├── kms.tf                  ← Lab 2.4 discipline: your CMK with rotation
+│   ├── evidence-vault.tf       ← Lab 2.5: Object Lock bucket
+│   ├── cloudtrail.tf           ← Lab 5.2: multi-region trail
+│   ├── oidc-trust.tf           ← Lab 4.3: GitHub OIDC role
+│   └── hardening.tf            ← gap-closing overrides on the starter's resources
+├── policies/
+│   ├── *.rego                  ← Lab 3.3 + 3.4: 5+ policies for your framework
+│   └── tests/*_test.rego       ← passing + failing fixtures
+├── scripts/
+│   ├── policy-gate.sh          ← Lab 3.4
+│   ├── capture-evidence.sh     ← Lab 2.5
+│   └── verify-evidence.sh      ← Lab 4.4
+├── .github/workflows/
+│   └── grc-gate.yml            ← Lab 4.3 + 4.4: plan→check→apply→sign→upload
+├── oscal/
+│   ├── components/<your-component>.json   ← Lab 6.1, controls swapped to your framework
+│   └── profiles/cge-p-minimum.json        ← Lab 6.1
+├── WRITEUP.md                  ← the graded reasoning document
+└── README.md                  ← short; grader verification steps
+```
+
+The point of laying it out this way is to make the assembly visible: nearly every file traces back to a lab you've already done. The capstone is the wiring, not the parts.
+
+### Scaffold the files you'll add on top of the starter
+
+After you fork and clone `cgep-app-starter`, run this once from that repo root so the new paths exist as empty files before you copy content over from `cgep-labs`. (Keep the starter's existing Terraform; this only adds the governance layer.)
+
+```bash
+# from your-cgep-capstone/ (fork of cgep-app-starter)
+mkdir -p \
+  terraform \
+  policies/tests \
+  scripts \
+  .github/workflows \
+  oscal/components \
+  oscal/profiles
+
+touch \
+  terraform/kms.tf \
+  terraform/evidence-vault.tf \
+  terraform/cloudtrail.tf \
+  terraform/oidc-trust.tf \
+  terraform/hardening.tf \
+  scripts/policy-gate.sh \
+  scripts/capture-evidence.sh \
+  scripts/verify-evidence.sh \
+  .github/workflows/grc-gate.yml \
+  oscal/components/your-component.json \
+  oscal/profiles/cge-p-minimum.json \
+  WRITEUP.md
+
+chmod +x scripts/*.sh
+
+find terraform policies scripts .github/workflows oscal WRITEUP.md -maxdepth 2 -type f 2>/dev/null | sort
+```
+
+When a later section says "bring over Lab 2.5's vault" or "paste your Lab 3.4 gate," open the matching empty file above and paste into that path — don't create a second copy under a different name.
+
+## The 30-day plan, with checkpoints
+
+Break it into weeks, and don't start on day 29. Each week has a checkpoint that tells you whether to keep going or cut scope.
+
+**Week 1, design.** Pick your framework, map your chosen controls to the eight gaps, sketch the repo structure, and write a one-page design doc in the repo. That doc becomes the spine of your `WRITEUP.md`, so this week is never wasted. *Checkpoint:* you can state, in a paragraph, your framework and which gaps you'll close in Terraform versus policy.
+
+**Week 2, build the infrastructure.** The Terraform baseline: KMS, the Object Lock evidence bucket, CloudTrail, and the gap-closing overrides. Apply it once by hand from a feature branch. *Checkpoint:* the baseline applies clean on its own. Do not start the pipeline until it does, because debugging Terraform through CI is far harder than debugging it locally.
+
+**Week 3, policy and pipeline.** Write your five-plus Rego policies, build the workflow, wire signing, and produce both PRs (the green one that merges and the red one the gate blocks). *Checkpoint:* a real PR run goes green, and a deliberately broken one goes red, both with evidence in the vault.
+
+**Week 4, OSCAL and write-up.** Author and validate the component definition, point its evidence links at real vault objects, then write the reflection and submit. *Checkpoint:* `trestle validate` passes and an evidence link resolves to a verifiable bundle.
+
+The brief's scope-cutting rule is worth memorizing: if you reach week three without a baseline running, cut workload scope to get a working pipeline. A small system with a real, signing, immutable evidence pipeline passes. A large system without one does not. Trade resources for the pipeline every single time.
+
+## How the grader verifies (so you can self-check first)
+
+Three things are scored hard, and you can check all three yourself before you submit:
+
+1. **End-to-end integration.** Open a PR and watch the chain actually connect: the gate runs, the gate's result decides whether apply happens, apply triggers signing, signing uploads to the vault. If those are four separate demos that don't trigger each other, that's the most common point loss. Confirm it's one connected flow.
+2. **A working evidence pipeline.** The grader pulls a recent run and runs the same three checks your Lab 4.4 `verify-evidence.sh` runs: the Cosign signature verifies against the public Sigstore log, the SHA-256 recomputes to match, and Object Lock retention is still active. Run your own verify script against your latest run before submitting. If it prints `CHAIN INTACT`, you've pre-passed the part graders weight most heavily.
+3. **Clear design reasoning.** Your write-up explains *why*, not just *what*. This is the next section.
+
+## Scaffolding your WRITEUP.md
+
+The write-up is not optional and honest gaps don't lose points, but hand-waving does. Graders would rather read "I didn't get to X, and here's how I'd approach it" than a vague claim of completeness. Here's a skeleton you can drop in and fill:
+
+```markdown
+# Acme Health: GRC Engineering Capstone Write-up
+
+## Primary framework
+[Name your framework in the first paragraph. Three sentences on why it fits
+this telehealth system better than the other two.]
+
+## Control coverage
+[For each gap from GAPS.md: which control it maps to, and whether you closed
+it in Terraform, enforced it in policy, or both. A table works well here.]
+
+## Design decisions
+[Walk each decision from the brief: region, Object Lock mode, apply-on-merge
+vs manual gate, single vs separate account, Terraform-vs-policy split.
+For each, state what you chose and the trade-off you accepted.]
+
+## How the pipeline produces evidence
+[Trace one run end to end: PR opened → gate → apply → sign → vault.
+Name the run ID an assessor can verify.]
+
+## Trade-offs and what I'd do with another sprint
+[Be specific and honest. This section earns more than a padded "everything works."]
+
+## What I didn't get to
+[Name it plainly. This costs nothing and signals judgment.]
+```
+
+If you wrote your one-page design doc in Week 1, most of the first three sections are already drafted.
+
+## Submission checklist
+
+The graded checklist is maintained in one place, the [Capstone Brief](07_01_capstone_brief.md#submission-checklist). Work from that list, not a copy of it, so you're never checking boxes against a stale version.
+
+## Three mistakes to avoid
+
+- **Too much scope.** Thirty resources cleanly integrated beat two hundred bolted on.
+- **Copy-paste OSCAL.** An OSCAL file that doesn't describe your real system is worse than none. Authenticity over completeness.
+- **Unsigned evidence.** A pipeline that produces a plan but never signs and immutably stores it hasn't demonstrated chain of custody, which is the entire point.
+
+## The finish line
+
+The output of all of this is one thing: a working evidence vault where every push to `main` produces a signed, timestamped artifact in immutable storage, automatically. An assessor who never meets you can start at your OSCAL component, follow a link to a vault object, verify it, and see `CHAIN INTACT`. That traversal is the whole course demonstrated in a single command, and if you did the labs, you've already built every link in it. Now you assemble them, wire them together, explain your choices, and ship.
+
+Ship the repo. Earn the cert.

--- a/guides/additional_resources.md
+++ b/guides/additional_resources.md
@@ -1,0 +1,53 @@
+# Additional Resources
+
+Curated videos and official docs for concepts used in the labs. Start with [Getting Started](../getting-started/tools.md) if you have not set up tools yet.
+
+## Terraform / Infrastructure as Code
+
+- [HashiCorp — Terraform explained (YouTube)](https://www.youtube.com/watch?v=h970ZBgGo58) — short mental model for plan/apply and providers before [Lab 2.3](02_03_first_compliant_resource.md).
+- [Terraform Install docs](https://developer.hashicorp.com/terraform/install) — official install paths referenced in Getting Started.
+- [Terraform Language docs](https://developer.hashicorp.com/terraform/language) — resources, modules, and variables used across Chapter 2.
+
+## AWS CLI
+
+- [AWS — Getting started with the AWS CLI (YouTube)](https://www.youtube.com/watch?v=Y2X_zXbf9LQ) — profiles, identity, and basic commands used before Terraform can authenticate.
+- [AWS CLI install guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) — vendor install instructions from Getting Started.
+- [sts get-caller-identity](https://docs.aws.amazon.com/cli/latest/reference/sts/get-caller-identity.html) — the connectivity check used in the labs.
+
+## OPA / Rego / Conftest
+
+- [Open Policy Agent — Introduction (YouTube)](https://www.youtube.com/watch?v=Xorjk5XOiOw) — why OPA exists before you write `deny` rules in [Lab 3.3](03_03_writing_compliance_policies_rego.md).
+- [OPA docs](https://www.openpolicyagent.org/docs) — language and CLI reference.
+- [Conftest docs](https://www.conftest.dev/) — running Rego against Terraform plan JSON in [Lab 3.4](03_04_integrating_pac_with_terraform.md).
+
+## OSCAL / trestle
+
+- [NIST — Introduction to OSCAL (YouTube)](https://www.youtube.com/watch?v=gq7PDc87M-U) — catalog / profile / component mental model for [Lab 6.1](06_01_introduction_to_oscal.md).
+- [OSCAL site](https://pages.nist.gov/OSCAL/) — official models and examples.
+- [compliance-trestle](https://github.com/oscal-compass/compliance-trestle) — the validation/authoring toolkit used in Lab 6.1.
+
+## GitHub Actions and OIDC
+
+- [GitHub — Introduction to GitHub Actions (YouTube)](https://www.youtube.com/watch?v=cP-cnX55YVY) — workflow basics before [Lab 4.3](04_03_grc_evidence_pipeline.md).
+- [Configuring OpenID Connect in Amazon Web Services](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) — the keyless AWS trust pattern used in Lab 4.3.
+
+## Evidence signing (Cosign / Sigstore)
+
+- [Sigstore — Overview (YouTube)](https://www.youtube.com/watch?v=BD9ezcZKGE8) — why keyless signing helps chain-of-custody claims in [Lab 4.4](04_04_evidence_chain_of_custody.md).
+- [Cosign docs](https://docs.sigstore.dev/cosign/system_config/installation/) — install and verify commands used with the evidence vault.
+
+## AWS security services
+
+- [AWS — AWS CloudTrail overview (YouTube)](https://www.youtube.com/watch?v=xoX48dSSOQw) — continuous activity logging for [Lab 5.2](05_02_aws_security_services.md).
+- [Security Hub user guide](https://docs.aws.amazon.com/securityhub/latest/userguide/what-is-securityhub.html) — findings aggregation mapped to controls.
+- [AWS Config developer guide](https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html) — configuration history / rules context from Lab 5.2.
+
+## GCP security services
+
+- [Google Cloud — Organization Policy Service (docs)](https://cloud.google.com/resource-manager/docs/organization-policy/overview) — guardrails used in [Lab 5.4](05_04_gcp_security_services.md).
+- [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation) — keyless federation concepts parallel to the AWS OIDC lab.
+- [Cloud Audit Logs](https://cloud.google.com/logging/docs/audit) — GCP's always-on admin/data access logging story.
+
+## How to suggest additions
+
+Open a PR that edits `wiki-source/Additional-Resources.md` in the main repo. Prefer official org channels and primary documentation over random tutorials.

--- a/guides/glossary.md
+++ b/guides/glossary.md
@@ -1,0 +1,153 @@
+# Glossary
+
+Alphabetical terms used across the CGEP labs. Lab pages are the source of deeper walkthroughs.
+
+## AWS CLI
+
+Command-line interface for AWS APIs. Terraform borrows credentials from a configured CLI profile (labs use `--profile default` unless you renamed it).
+
+See: [Getting Started](../getting-started/tools.md), [Lab 2.3](02_03_first_compliant_resource.md)
+
+## AWS Config
+
+AWS service that records resource configuration over time and can evaluate rules continuously.
+
+See: [Lab 5.2](05_02_aws_security_services.md)
+
+## CMEK
+
+Customer-managed encryption key — a key you control (for example in Cloud KMS) used to encrypt data at rest instead of a provider-managed default.
+
+See: [Lab 2.4](02_04_terraform_modules_for_compliance.md), [Lab 3.3](03_03_writing_compliance_policies_rego.md)
+
+## Catalog
+
+In OSCAL, a library of controls (for example NIST SP 800-53). Profiles select controls from catalogs.
+
+See: [Lab 6.1](06_01_introduction_to_oscal.md)
+
+## Chain of custody
+
+Properties that keep evidence trustworthy over time: integrity, authenticity/timestamp, and preservation (for example Object Lock retention).
+
+See: [Lab 4.4](04_04_evidence_chain_of_custody.md)
+
+## CloudTrail
+
+AWS account activity log of API calls and related events; foundation for continuous monitoring evidence.
+
+See: [Lab 5.2](05_02_aws_security_services.md)
+
+## Component Definition
+
+OSCAL model describing how a software/infrastructure component implements specific controls, often with links to evidence.
+
+See: [Lab 6.1](06_01_introduction_to_oscal.md)
+
+## compliance-trestle
+
+NIST's Python toolkit for authoring and validating OSCAL content (`pip install compliance-trestle`).
+
+See: [Lab 6.1](06_01_introduction_to_oscal.md)
+
+## Conftest
+
+Policy runner that evaluates Rego against structured inputs such as `terraform show -json` plans; used as the local/CI gate.
+
+See: [Lab 3.4](03_04_integrating_pac_with_terraform.md), [Lab 4.3](04_03_grc_evidence_pipeline.md)
+
+## Cosign / Sigstore
+
+Keyless (or keyed) signing tooling used to sign evidence bundles so authenticity can be verified later.
+
+See: [Lab 2.5](02_05_iac_as_compliance_evidence.md), [Lab 4.4](04_04_evidence_chain_of_custody.md)
+
+## Evidence vault
+
+S3 bucket (with Object Lock in these labs) that stores signed compliance evidence artifacts outside day-to-day scratch space.
+
+See: [Lab 2.5](02_05_iac_as_compliance_evidence.md), [Lab 4.4](04_04_evidence_chain_of_custody.md)
+
+## GitHub Actions
+
+GitHub-hosted CI that runs workflows from `.github/workflows/` on events such as pull requests.
+
+See: [Lab 4.3](04_03_grc_evidence_pipeline.md)
+
+## Google Cloud CLI (`gcloud`)
+
+Command-line interface for GCP; used in GCP labs for verify/cleanup commands.
+
+See: [Getting Started](../getting-started/tools.md), [Lab 2.4](02_04_terraform_modules_for_compliance.md)
+
+## IaC evidence
+
+Machine-readable proof captured from infrastructure tooling (plans, state snapshots, scanner outputs) instead of screenshots.
+
+See: [Lab 2.3](02_03_first_compliant_resource.md), [Lab 2.5](02_05_iac_as_compliance_evidence.md)
+
+## NIST 800-53
+
+NIST SP 800-53 control catalog commonly referenced by the labs (for example SC-28, AC-3, AU-3, CM-6).
+
+See: [Lab 2.3](02_03_first_compliant_resource.md), [Lab 3.3](03_03_writing_compliance_policies_rego.md)
+
+## Object Lock
+
+S3 feature that enforces WORM retention (COMPLIANCE or GOVERNANCE mode) so evidence objects cannot be quietly altered or deleted early.
+
+See: [Lab 2.5](02_05_iac_as_compliance_evidence.md), [Lab 4.4](04_04_evidence_chain_of_custody.md)
+
+## OIDC (GitHub → AWS)
+
+OpenID Connect trust so GitHub Actions can assume an AWS IAM role without long-lived access keys.
+
+See: [Lab 4.3](04_03_grc_evidence_pipeline.md)
+
+## OPA (Open Policy Agent)
+
+Policy engine that evaluates Rego. Local `opa test` / `opa eval` and Conftest both sit in this ecosystem.
+
+See: [Lab 3.3](03_03_writing_compliance_policies_rego.md)
+
+## OSCAL
+
+NIST's machine-readable format for catalogs, profiles, components, and assessment artifacts — documentation that can be traversed and validated.
+
+See: [Lab 6.1](06_01_introduction_to_oscal.md)
+
+## Policy as Code
+
+Expressing compliance/security rules as executable policies checked automatically against infrastructure definitions or plans.
+
+See: [Lab 3.3](03_03_writing_compliance_policies_rego.md), [Lab 3.4](03_04_integrating_pac_with_terraform.md)
+
+## Profile
+
+OSCAL model that selects and tailors a subset of controls from one or more catalogs.
+
+See: [Lab 6.1](06_01_introduction_to_oscal.md)
+
+## Rego
+
+OPA's policy language. Labs write `deny` rules that fail non-compliant Terraform plans.
+
+See: [Lab 3.3](03_03_writing_compliance_policies_rego.md)
+
+## Security Hub
+
+AWS service that aggregates findings and maps them to standards/controls (including NIST).
+
+See: [Lab 5.2](05_02_aws_security_services.md)
+
+## Terraform
+
+HashiCorp tool that declares cloud resources as code (`.tf`) and applies them through providers.
+
+See: [Getting Started](../getting-started/tools.md), [Lab 2.3](02_03_first_compliant_resource.md)
+
+## tfsec / Trivy
+
+Static scanners for Terraform misconfigurations. The pipeline lab uses tfsec; Trivy (`trivy config`) is the supported successor with overlapping checks.
+
+See: [Lab 4.3](04_03_grc_evidence_pipeline.md)


### PR DESCRIPTION
Ports [Dex Copeland's reworked CGEP lab guides](https://github.com/dexcopeland/cgep-lab-guide-rework) into this repo, under the existing filenames, so every member gets them through the links the Academy already points at. Nobody has to find the rework repo.

## What changed

**A one-time setup that the guides always assumed but never taught.** `getting-started/tools.md` and `getting-started/repo-structure.md` cover Git Bash on Windows (including `core.autocrlf`), Terraform, the AWS CLI, and the `cgep-labs` repo shape every lab writes into. Ten of the eleven guides already linked to `../getting-started/tools.md` and `../getting-started/repo-structure.md` in Dex's drafts; those targets now exist. Lab 2.3 had the same content inline, so it now carries the same "Before you begin" callout as its siblings rather than a second copy that would drift.

**The guides themselves.** Plain-language control tables (what SC-28 means before you write the Terraform), consistent repo paths across labs, a commit step at the end of each lab so the portfolio builds as you go, and corrected time and cost estimates. Lab 5.2 now opens with an explicit "this lab costs real money" section.

**`guides/07_02_capstone_companion.md`.** The brief stays the graded contract. The companion is the assembly walkthrough: the deploy gate, which lab artifact becomes which layer, a worked repo layout, and a write-up scaffold. Its submission checklist points at the brief's instead of duplicating it, so there's one list to keep current.

**`guides/glossary.md` and `guides/additional_resources.md`.** Appendix pages, wiki-syntax links converted to relative repo links.

## Verification

- 91 relative links resolve, 0 broken.
- 37 of 40 external URLs return live. The other three are placeholders inside fenced code blocks (`https://github.com/<your-username>`, the OIDC issuer, an OIDC subject claim), which markdown-link-check does not follow.
- `reference/` is untouched, so the opa, terraform, and trestle jobs are unaffected by this change.

## Follow-on

`cert.grcengclub.com/labs` gets a matching update: a "Start here" card for the setup guide, a card for the companion, Lab 5.2's cost warning on the card, and the corrected durations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive setup guides for tools, repository structure, authentication, and evidence organization.
  - Expanded lab instructions with clearer prerequisites, step-by-step workflows, validation, troubleshooting, evidence capture, cleanup, and submission guidance.
  - Added a capstone companion covering project planning, compliance layers, repository assembly, grading checks, and write-up requirements.
  - Added a glossary and curated resource guide with references for Terraform, cloud security, policy tools, OSCAL, CI/CD, and signing.
  - Clarified the capstone brief and identified the graded contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->